### PR TITLE
Import code from the SDK v1.0.0-rc5

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 # Fallback owner.
 # These are the default owners for everything in the repo, unless a later match
 # takes precedence.
-* @frequenz-floss/api-microgrid-team
+* @frequenz-floss/api-microgrid-team @frequenz-floss/python-sdk-team

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
+Code import from the [SDK v1.0.0-rc5](https://github.com/frequenz-floss/frequenz-sdk-python/releases/tag/v1.0.0-rc5) release.
 
 ## Upgrading
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,10 @@ plugins:
           import:
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv
+            - https://frequenz-floss.github.io/frequenz-api-common/v0.5/objects.inv
+            - https://frequenz-floss.github.io/frequenz-api-microgrid/v0.15/objects.inv
+            - https://frequenz-floss.github.io/frequenz-channels-python/v1.0-pre/objects.inv
+            - https://grpc.github.io/grpc/python/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
   # Note this plugin must be loaded after mkdocstrings to be able to use macros
   # inside docstrings. See the comment in `docs/_scripts/macros.py` for more

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,11 @@ classifiers = [
   "Typing :: Typed",
 ]
 requires-python = ">= 3.11, < 4"
-# TODO(cookiecutter): Remove and add more dependencies if appropriate
 dependencies = [
+  "frequenz-api-microgrid >= 0.15.3, < 0.16.0",
+  "frequenz-channels == 1.0.0b2",
+  "grpcio >= 1.54.2, < 2",
+  "timezonefinder >= 6.2.0, < 7",
   "typing-extensions >= 4.5.0, < 5",
 ]
 dynamic = ["version"]

--- a/src/frequenz/client/microgrid/__init__.py
+++ b/src/frequenz/client/microgrid/__init__.py
@@ -1,0 +1,4 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Client to connect to the Microgrid API."""

--- a/src/frequenz/client/microgrid/_client.py
+++ b/src/frequenz/client/microgrid/_client.py
@@ -231,7 +231,14 @@ class MicrogridGrpcClient(MicrogridApiClient):
             raise grpc.aio.AioRpcError(
                 code=err.code(),
                 initial_metadata=err.initial_metadata(),
-                trailing_metadata=err.trailing_metadata(),
+                # We need to ignore these errors for some reason, otherwise we get this
+                # mypy error:
+                #   Argument "trailing_metadata" to "AioRpcError" has incompatible type
+                #   "tuple[_Metadatum, ...]"; expected "Metadata"
+                # According to grpc.aio documentation, both should have the type
+                # Metadata.
+                # https://grpc.github.io/grpc/python/grpc_asyncio.html#grpc.aio.AioRpcError
+                trailing_metadata=err.trailing_metadata(),  # type: ignore[arg-type]
                 details=msg,
                 debug_error_string=err.debug_error_string(),
             )
@@ -324,7 +331,8 @@ class MicrogridGrpcClient(MicrogridApiClient):
             raise grpc.aio.AioRpcError(
                 code=err.code(),
                 initial_metadata=err.initial_metadata(),
-                trailing_metadata=err.trailing_metadata(),
+                # See the comment in def components() for why we need to ignore
+                trailing_metadata=err.trailing_metadata(),  # type: ignore[arg-type]
                 details=msg,
                 debug_error_string=err.debug_error_string(),
             )
@@ -600,7 +608,8 @@ class MicrogridGrpcClient(MicrogridApiClient):
             raise grpc.aio.AioRpcError(
                 code=err.code(),
                 initial_metadata=err.initial_metadata(),
-                trailing_metadata=err.trailing_metadata(),
+                # See the comment in def components() for why we need to ignore
+                trailing_metadata=err.trailing_metadata(),  # type: ignore[arg-type]
                 details=msg,
                 debug_error_string=err.debug_error_string(),
             )

--- a/src/frequenz/client/microgrid/_client.py
+++ b/src/frequenz/client/microgrid/_client.py
@@ -1,0 +1,657 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Client for requests to the Microgrid API."""
+
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Any, TypeVar, cast
+
+import grpc
+from frequenz.api.common import components_pb2 as components_pb
+from frequenz.api.common import metrics_pb2 as metrics_pb
+from frequenz.api.microgrid import microgrid_pb2 as microgrid_pb
+from frequenz.api.microgrid.microgrid_pb2_grpc import MicrogridStub
+from frequenz.channels import Broadcast, Receiver, Sender
+from google.protobuf.empty_pb2 import Empty  # pylint: disable=no-name-in-module
+
+from ..._internal._constants import RECEIVER_MAX_SIZE
+from ..component import (
+    BatteryData,
+    Component,
+    ComponentCategory,
+    EVChargerData,
+    InverterData,
+    MeterData,
+)
+from ..component._component import (
+    _component_category_from_protobuf,
+    _component_metadata_from_protobuf,
+    _component_type_from_protobuf,
+)
+from ..metadata import Location, Metadata
+from ._connection import Connection
+from ._retry import LinearBackoff, RetryStrategy
+
+DEFAULT_GRPC_CALL_TIMEOUT = 60.0
+"""The default timeout for gRPC calls made by this client (in seconds)."""
+
+# A generic type for representing various component data types, used in the
+# generic function `MicrogridGrpcClient._component_data_task` that fetches
+# component data and transforms it into one of the specific types.
+_GenericComponentData = TypeVar(
+    "_GenericComponentData",
+    MeterData,
+    BatteryData,
+    InverterData,
+    EVChargerData,
+)
+"""Type variable for representing various component data types."""
+
+_logger = logging.getLogger(__name__)
+
+
+class MicrogridApiClient(ABC):
+    """Base interface for microgrid API clients to implement."""
+
+    @abstractmethod
+    async def components(self) -> Iterable[Component]:
+        """Fetch all the components present in the microgrid.
+
+        Returns:
+            Iterator whose elements are all the components in the microgrid.
+        """
+
+    @abstractmethod
+    async def metadata(self) -> Metadata:
+        """Fetch the microgrid metadata.
+
+        Returns:
+            the microgrid metadata.
+        """
+
+    @abstractmethod
+    async def connections(
+        self,
+        starts: set[int] | None = None,
+        ends: set[int] | None = None,
+    ) -> Iterable[Connection]:
+        """Fetch the connections between components in the microgrid.
+
+        Args:
+            starts: if set and non-empty, only include connections whose start
+                value matches one of the provided component IDs
+            ends: if set and non-empty, only include connections whose end value
+                matches one of the provided component IDs
+
+        Returns:
+            Microgrid connections matching the provided start and end filters.
+        """
+
+    @abstractmethod
+    async def meter_data(
+        self,
+        component_id: int,
+        maxsize: int = RECEIVER_MAX_SIZE,
+    ) -> Receiver[MeterData]:
+        """Return a channel receiver that provides a `MeterData` stream.
+
+        Args:
+            component_id: id of the meter to get data for.
+            maxsize: Size of the receiver's buffer.
+
+        Returns:
+            A channel receiver that provides realtime meter data.
+        """
+
+    @abstractmethod
+    async def battery_data(
+        self,
+        component_id: int,
+        maxsize: int = RECEIVER_MAX_SIZE,
+    ) -> Receiver[BatteryData]:
+        """Return a channel receiver that provides a `BatteryData` stream.
+
+        Args:
+            component_id: id of the battery to get data for.
+            maxsize: Size of the receiver's buffer.
+
+        Returns:
+            A channel receiver that provides realtime battery data.
+        """
+
+    @abstractmethod
+    async def inverter_data(
+        self,
+        component_id: int,
+        maxsize: int = RECEIVER_MAX_SIZE,
+    ) -> Receiver[InverterData]:
+        """Return a channel receiver that provides an `InverterData` stream.
+
+        Args:
+            component_id: id of the inverter to get data for.
+            maxsize: Size of the receiver's buffer.
+
+        Returns:
+            A channel receiver that provides realtime inverter data.
+        """
+
+    @abstractmethod
+    async def ev_charger_data(
+        self,
+        component_id: int,
+        maxsize: int = RECEIVER_MAX_SIZE,
+    ) -> Receiver[EVChargerData]:
+        """Return a channel receiver that provides an `EvChargeData` stream.
+
+        Args:
+            component_id: id of the ev charger to get data for.
+            maxsize: Size of the receiver's buffer.
+
+        Returns:
+            A channel receiver that provides realtime ev charger data.
+        """
+
+    @abstractmethod
+    async def set_power(self, component_id: int, power_w: float) -> None:
+        """Send request to the Microgrid to set power for component.
+
+        If power > 0, then component will be charged with this power.
+        If power < 0, then component will be discharged with this power.
+        If power == 0, then stop charging or discharging component.
+
+
+        Args:
+            component_id: id of the component to set power.
+            power_w: power to set for the component.
+        """
+
+    @abstractmethod
+    async def set_bounds(self, component_id: int, lower: float, upper: float) -> None:
+        """Send `SetBoundsParam`s received from a channel to the Microgrid service.
+
+        Args:
+            component_id: ID of the component to set bounds for.
+            lower: Lower bound to be set for the component.
+            upper: Upper bound to be set for the component.
+        """
+
+
+# pylint: disable=no-member
+
+
+class MicrogridGrpcClient(MicrogridApiClient):
+    """Microgrid API client implementation using gRPC as the underlying protocol."""
+
+    def __init__(
+        self,
+        grpc_channel: grpc.aio.Channel,
+        target: str,
+        retry_spec: RetryStrategy = LinearBackoff(),
+    ) -> None:
+        """Initialize the class instance.
+
+        Args:
+            grpc_channel: asyncio-supporting gRPC channel
+            target: server (host:port) to be used for asyncio-supporting gRPC
+                channel that the client should use to contact the API
+            retry_spec: Specs on how to retry if the connection to a streaming
+                method gets lost.
+        """
+        self.target = target
+        """The location (as "host:port") of the microgrid API gRPC server."""
+
+        self.api = MicrogridStub(grpc_channel)
+        """The gRPC stub for the microgrid API."""
+
+        self._component_streams: dict[int, Broadcast[Any]] = {}
+        self._streaming_tasks: dict[int, asyncio.Task[None]] = {}
+        self._retry_spec = retry_spec
+
+    async def components(self) -> Iterable[Component]:
+        """Fetch all the components present in the microgrid.
+
+        Returns:
+            Iterator whose elements are all the components in the microgrid.
+
+        Raises:
+            AioRpcError: if connection to Microgrid API cannot be established or
+                when the api call exceeded timeout
+        """
+        try:
+            # grpc.aio is missing types and mypy thinks this is not awaitable,
+            # but it is
+            component_list = await cast(
+                Awaitable[microgrid_pb.ComponentList],
+                self.api.ListComponents(
+                    microgrid_pb.ComponentFilter(),
+                    timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
+                ),
+            )
+
+        except grpc.aio.AioRpcError as err:
+            msg = f"Failed to list components. Microgrid API: {self.target}. Err: {err.details()}"
+            raise grpc.aio.AioRpcError(
+                code=err.code(),
+                initial_metadata=err.initial_metadata(),
+                trailing_metadata=err.trailing_metadata(),
+                details=msg,
+                debug_error_string=err.debug_error_string(),
+            )
+        components_only = filter(
+            lambda c: c.category
+            is not components_pb.ComponentCategory.COMPONENT_CATEGORY_SENSOR,
+            component_list.components,
+        )
+        result: Iterable[Component] = map(
+            lambda c: Component(
+                c.id,
+                _component_category_from_protobuf(c.category),
+                _component_type_from_protobuf(c.category, c.inverter),
+                _component_metadata_from_protobuf(c.category, c.grid),
+            ),
+            components_only,
+        )
+
+        return result
+
+    async def metadata(self) -> Metadata:
+        """Fetch the microgrid metadata.
+
+        If there is an error fetching the metadata, the microgrid ID and
+        location will be set to None.
+
+        Returns:
+            the microgrid metadata.
+        """
+        microgrid_metadata: microgrid_pb.MicrogridMetadata | None = None
+        try:
+            microgrid_metadata = await cast(
+                Awaitable[microgrid_pb.MicrogridMetadata],
+                self.api.GetMicrogridMetadata(
+                    Empty(),
+                    timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
+                ),
+            )
+        except grpc.aio.AioRpcError:
+            _logger.exception("The microgrid metadata is not available.")
+
+        if not microgrid_metadata:
+            return Metadata()
+
+        location: Location | None = None
+        if microgrid_metadata.location:
+            location = Location(
+                latitude=microgrid_metadata.location.latitude,
+                longitude=microgrid_metadata.location.longitude,
+            )
+
+        return Metadata(microgrid_id=microgrid_metadata.microgrid_id, location=location)
+
+    async def connections(
+        self,
+        starts: set[int] | None = None,
+        ends: set[int] | None = None,
+    ) -> Iterable[Connection]:
+        """Fetch the connections between components in the microgrid.
+
+        Args:
+            starts: if set and non-empty, only include connections whose start
+                value matches one of the provided component IDs
+            ends: if set and non-empty, only include connections whose end value
+                matches one of the provided component IDs
+
+        Returns:
+            Microgrid connections matching the provided start and end filters.
+
+        Raises:
+            AioRpcError: if connection to Microgrid API cannot be established or
+                when the api call exceeded timeout
+        """
+        connection_filter = microgrid_pb.ConnectionFilter(starts=starts, ends=ends)
+        try:
+            valid_components, all_connections = await asyncio.gather(
+                self.components(),
+                # grpc.aio is missing types and mypy thinks this is not
+                # awaitable, but it is
+                cast(
+                    Awaitable[microgrid_pb.ConnectionList],
+                    self.api.ListConnections(
+                        connection_filter,
+                        timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
+                    ),
+                ),
+            )
+        except grpc.aio.AioRpcError as err:
+            msg = f"Failed to list connections. Microgrid API: {self.target}. Err: {err.details()}"
+            raise grpc.aio.AioRpcError(
+                code=err.code(),
+                initial_metadata=err.initial_metadata(),
+                trailing_metadata=err.trailing_metadata(),
+                details=msg,
+                debug_error_string=err.debug_error_string(),
+            )
+        # Filter out the components filtered in `components` method.
+        # id=0 is an exception indicating grid component.
+        valid_ids = {c.component_id for c in valid_components}
+        valid_ids.add(0)
+
+        connections = filter(
+            lambda c: (c.start in valid_ids and c.end in valid_ids),
+            all_connections.connections,
+        )
+
+        result: Iterable[Connection] = map(
+            lambda c: Connection(c.start, c.end), connections
+        )
+
+        return result
+
+    async def _component_data_task(
+        self,
+        component_id: int,
+        transform: Callable[[microgrid_pb.ComponentData], _GenericComponentData],
+        sender: Sender[_GenericComponentData],
+    ) -> None:
+        """Read data from the microgrid API and send to a channel.
+
+        Args:
+            component_id: id of the component to get data for.
+            transform: A method for transforming raw component data into the
+                desired output type.
+            sender: A channel sender, to send the component data to.
+        """
+        retry_spec: RetryStrategy = self._retry_spec.copy()
+        while True:
+            _logger.debug(
+                "Making call to `GetComponentData`, for component_id=%d", component_id
+            )
+            try:
+                call = self.api.StreamComponentData(
+                    microgrid_pb.ComponentIdParam(id=component_id),
+                )
+                # grpc.aio is missing types and mypy thinks this is not
+                # async iterable, but it is
+                async for msg in call:  # type: ignore[attr-defined]
+                    await sender.send(transform(msg))
+            except grpc.aio.AioRpcError as err:
+                api_details = f"Microgrid API: {self.target}."
+                _logger.exception(
+                    "`GetComponentData`, for component_id=%d: exception: %s api: %s",
+                    component_id,
+                    err,
+                    api_details,
+                )
+
+            if interval := retry_spec.next_interval():
+                _logger.warning(
+                    "`GetComponentData`, for component_id=%d: connection ended, "
+                    "retrying %s in %0.3f seconds.",
+                    component_id,
+                    retry_spec.get_progress(),
+                    interval,
+                )
+                await asyncio.sleep(interval)
+            else:
+                _logger.warning(
+                    "`GetComponentData`, for component_id=%d: connection ended, "
+                    "retry limit exceeded %s.",
+                    component_id,
+                    retry_spec.get_progress(),
+                )
+                break
+
+    def _get_component_data_channel(
+        self,
+        component_id: int,
+        transform: Callable[[microgrid_pb.ComponentData], _GenericComponentData],
+    ) -> Broadcast[_GenericComponentData]:
+        """Return the broadcast channel for a given component_id.
+
+        If a broadcast channel for the given component_id doesn't exist, create
+        a new channel and a task for reading data from the microgrid api and
+        sending them to the channel.
+
+        Args:
+            component_id: id of the component to get data for.
+            transform: A method for transforming raw component data into the
+                desired output type.
+
+        Returns:
+            The channel for the given component_id.
+        """
+        if component_id in self._component_streams:
+            return self._component_streams[component_id]
+        task_name = f"raw-component-data-{component_id}"
+        chan = Broadcast[_GenericComponentData](task_name, resend_latest=True)
+        self._component_streams[component_id] = chan
+
+        self._streaming_tasks[component_id] = asyncio.create_task(
+            self._component_data_task(
+                component_id,
+                transform,
+                chan.new_sender(),
+            ),
+            name=task_name,
+        )
+        return chan
+
+    async def _expect_category(
+        self,
+        component_id: int,
+        expected_category: ComponentCategory,
+    ) -> None:
+        """Check if the given component_id is of the expected type.
+
+        Raises:
+            ValueError: if the given id is unknown or has a different type.
+
+        Args:
+            component_id: Component id to check.
+            expected_category: Component category that the given id is expected
+                to have.
+        """
+        try:
+            comp = next(
+                comp
+                for comp in await self.components()
+                if comp.component_id == component_id
+            )
+        except StopIteration as exc:
+            raise ValueError(
+                f"Unable to find component with id {component_id}"
+            ) from exc
+
+        if comp.category != expected_category:
+            raise ValueError(
+                f"Component id {component_id} is a {comp.category}"
+                f", not a {expected_category}."
+            )
+
+    async def meter_data(  # noqa: DOC502 (ValueError is raised indirectly by _expect_category)
+        self,
+        component_id: int,
+        maxsize: int = RECEIVER_MAX_SIZE,
+    ) -> Receiver[MeterData]:
+        """Return a channel receiver that provides a `MeterData` stream.
+
+        Raises:
+            ValueError: if the given id is unknown or has a different type.
+
+        Args:
+            component_id: id of the meter to get data for.
+            maxsize: Size of the receiver's buffer.
+
+        Returns:
+            A channel receiver that provides realtime meter data.
+        """
+        await self._expect_category(
+            component_id,
+            ComponentCategory.METER,
+        )
+        return self._get_component_data_channel(
+            component_id,
+            MeterData.from_proto,
+        ).new_receiver(maxsize=maxsize)
+
+    async def battery_data(  # noqa: DOC502 (ValueError is raised indirectly by _expect_category)
+        self,
+        component_id: int,
+        maxsize: int = RECEIVER_MAX_SIZE,
+    ) -> Receiver[BatteryData]:
+        """Return a channel receiver that provides a `BatteryData` stream.
+
+        Raises:
+            ValueError: if the given id is unknown or has a different type.
+
+        Args:
+            component_id: id of the battery to get data for.
+            maxsize: Size of the receiver's buffer.
+
+        Returns:
+            A channel receiver that provides realtime battery data.
+        """
+        await self._expect_category(
+            component_id,
+            ComponentCategory.BATTERY,
+        )
+        return self._get_component_data_channel(
+            component_id,
+            BatteryData.from_proto,
+        ).new_receiver(maxsize=maxsize)
+
+    async def inverter_data(  # noqa: DOC502 (ValueError is raised indirectly by _expect_category)
+        self,
+        component_id: int,
+        maxsize: int = RECEIVER_MAX_SIZE,
+    ) -> Receiver[InverterData]:
+        """Return a channel receiver that provides an `InverterData` stream.
+
+        Raises:
+            ValueError: if the given id is unknown or has a different type.
+
+        Args:
+            component_id: id of the inverter to get data for.
+            maxsize: Size of the receiver's buffer.
+
+        Returns:
+            A channel receiver that provides realtime inverter data.
+        """
+        await self._expect_category(
+            component_id,
+            ComponentCategory.INVERTER,
+        )
+        return self._get_component_data_channel(
+            component_id,
+            InverterData.from_proto,
+        ).new_receiver(maxsize=maxsize)
+
+    async def ev_charger_data(  # noqa: DOC502 (ValueError is raised indirectly by _expect_category)
+        self,
+        component_id: int,
+        maxsize: int = RECEIVER_MAX_SIZE,
+    ) -> Receiver[EVChargerData]:
+        """Return a channel receiver that provides an `EvChargeData` stream.
+
+        Raises:
+            ValueError: if the given id is unknown or has a different type.
+
+        Args:
+            component_id: id of the ev charger to get data for.
+            maxsize: Size of the receiver's buffer.
+
+        Returns:
+            A channel receiver that provides realtime ev charger data.
+        """
+        await self._expect_category(
+            component_id,
+            ComponentCategory.EV_CHARGER,
+        )
+        return self._get_component_data_channel(
+            component_id,
+            EVChargerData.from_proto,
+        ).new_receiver(maxsize=maxsize)
+
+    async def set_power(self, component_id: int, power_w: float) -> None:
+        """Send request to the Microgrid to set power for component.
+
+        If power > 0, then component will be charged with this power.
+        If power < 0, then component will be discharged with this power.
+        If power == 0, then stop charging or discharging component.
+
+
+        Args:
+            component_id: id of the component to set power.
+            power_w: power to set for the component.
+
+        Raises:
+            AioRpcError: if connection to Microgrid API cannot be established or
+                when the api call exceeded timeout
+        """
+        try:
+            await cast(
+                Awaitable[microgrid_pb.SetPowerActiveParam],
+                self.api.SetPowerActive(
+                    microgrid_pb.SetPowerActiveParam(
+                        component_id=component_id, power=power_w
+                    ),
+                    timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
+                ),
+            )
+        except grpc.aio.AioRpcError as err:
+            msg = f"Failed to set power. Microgrid API: {self.target}. Err: {err.details()}"
+            raise grpc.aio.AioRpcError(
+                code=err.code(),
+                initial_metadata=err.initial_metadata(),
+                trailing_metadata=err.trailing_metadata(),
+                details=msg,
+                debug_error_string=err.debug_error_string(),
+            )
+
+    async def set_bounds(
+        self,
+        component_id: int,
+        lower: float,
+        upper: float,
+    ) -> None:
+        """Send `SetBoundsParam`s received from a channel to the Microgrid service.
+
+        Args:
+            component_id: ID of the component to set bounds for.
+            lower: Lower bound to be set for the component.
+            upper: Upper bound to be set for the component.
+
+        Raises:
+            ValueError: when upper bound is less than 0, or when lower bound is
+                greater than 0.
+            grpc.aio.AioRpcError: if connection to Microgrid API cannot be established
+                or when the api call exceeded timeout
+        """
+        api_details = f"Microgrid API: {self.target}."
+        if upper < 0:
+            raise ValueError(f"Upper bound {upper} must be greater than or equal to 0.")
+        if lower > 0:
+            raise ValueError(f"Lower bound {upper} must be less than or equal to 0.")
+
+        target_metric = (
+            microgrid_pb.SetBoundsParam.TargetMetric.TARGET_METRIC_POWER_ACTIVE
+        )
+        try:
+            self.api.AddInclusionBounds(
+                microgrid_pb.SetBoundsParam(
+                    component_id=component_id,
+                    target_metric=target_metric,
+                    bounds=metrics_pb.Bounds(lower=lower, upper=upper),
+                ),
+            )
+        except grpc.aio.AioRpcError as err:
+            _logger.error(
+                "set_bounds write failed: %s, for message: %s, api: %s. Err: %s",
+                err,
+                next,
+                api_details,
+                err.details(),
+            )
+            raise

--- a/src/frequenz/client/microgrid/_client.py
+++ b/src/frequenz/client/microgrid/_client.py
@@ -17,23 +17,18 @@ from frequenz.api.microgrid.microgrid_pb2_grpc import MicrogridStub
 from frequenz.channels import Broadcast, Receiver, Sender
 from google.protobuf.empty_pb2 import Empty  # pylint: disable=no-name-in-module
 
-from ..._internal._constants import RECEIVER_MAX_SIZE
-from ..component import (
-    BatteryData,
+from ._component import (
     Component,
     ComponentCategory,
-    EVChargerData,
-    InverterData,
-    MeterData,
-)
-from ..component._component import (
     _component_category_from_protobuf,
     _component_metadata_from_protobuf,
     _component_type_from_protobuf,
 )
-from ..metadata import Location, Metadata
+from ._component_data import BatteryData, EVChargerData, InverterData, MeterData
 from ._connection import Connection
+from ._constants import RECEIVER_MAX_SIZE
 from ._retry import LinearBackoff, RetryStrategy
+from .metadata import Location, Metadata
 
 DEFAULT_GRPC_CALL_TIMEOUT = 60.0
 """The default timeout for gRPC calls made by this client (in seconds)."""

--- a/src/frequenz/client/microgrid/_component.py
+++ b/src/frequenz/client/microgrid/_component.py
@@ -57,11 +57,7 @@ def _component_type_from_protobuf(
         component_category
         == components_pb.ComponentCategory.COMPONENT_CATEGORY_INVERTER
     ):
-        # mypy 1.4.1 crashes at this line, maybe it doesn't like the name of the "type"
-        # attribute in this context.  Hence the "# type: ignore".
-        if not any(
-            t.value == component_metadata.type for t in InverterType  # type: ignore
-        ):
+        if not any(int(t.value) == int(component_metadata.type) for t in InverterType):
             return None
 
         return InverterType(component_metadata.type)

--- a/src/frequenz/client/microgrid/_component.py
+++ b/src/frequenz/client/microgrid/_component.py
@@ -6,15 +6,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING
 
 import frequenz.api.common.components_pb2 as components_pb
 import frequenz.api.microgrid.grid_pb2 as grid_pb
 import frequenz.api.microgrid.inverter_pb2 as inverter_pb
-
-if TYPE_CHECKING:
-    # Break circular import
-    from ...timeseries import Fuse
 
 
 class ComponentType(Enum):
@@ -127,6 +122,14 @@ def _component_category_from_protobuf(
 
 
 @dataclass(frozen=True)
+class Fuse:
+    """Fuse data class."""
+
+    max_current: float
+    """Rated current of the fuse."""
+
+
+@dataclass(frozen=True)
 class ComponentMetadata:
     """Base class for component metadata classes."""
 
@@ -143,10 +146,8 @@ def _component_metadata_from_protobuf(
     component_category: components_pb.ComponentCategory.ValueType,
     component_metadata: grid_pb.Metadata,
 ) -> GridMetadata | None:
-    from ...timeseries import Current, Fuse  # pylint: disable=import-outside-toplevel
-
     if component_category == components_pb.ComponentCategory.COMPONENT_CATEGORY_GRID:
-        max_current = Current.from_amperes(component_metadata.rated_fuse_current)
+        max_current = component_metadata.rated_fuse_current
         fuse = Fuse(max_current)
         return GridMetadata(fuse)
 

--- a/src/frequenz/client/microgrid/_component.py
+++ b/src/frequenz/client/microgrid/_component.py
@@ -1,0 +1,249 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Defines the components that can be used in a microgrid."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+import frequenz.api.common.components_pb2 as components_pb
+import frequenz.api.microgrid.grid_pb2 as grid_pb
+import frequenz.api.microgrid.inverter_pb2 as inverter_pb
+
+if TYPE_CHECKING:
+    # Break circular import
+    from ...timeseries import Fuse
+
+
+class ComponentType(Enum):
+    """A base class from which individual component types are derived."""
+
+
+# pylint: disable=no-member
+
+
+class InverterType(ComponentType):
+    """Enum representing inverter types."""
+
+    NONE = inverter_pb.Type.TYPE_UNSPECIFIED
+    """Unspecified inverter type."""
+
+    BATTERY = inverter_pb.Type.TYPE_BATTERY
+    """Battery inverter."""
+
+    SOLAR = inverter_pb.Type.TYPE_SOLAR
+    """Solar inverter."""
+
+    HYBRID = inverter_pb.Type.TYPE_HYBRID
+    """Hybrid inverter."""
+
+
+def _component_type_from_protobuf(
+    component_category: components_pb.ComponentCategory.ValueType,
+    component_metadata: inverter_pb.Metadata,
+) -> ComponentType | None:
+    """Convert a protobuf InverterType message to Component enum.
+
+    For internal-only use by the `microgrid` package.
+
+    Args:
+        component_category: category the type belongs to.
+        component_metadata: protobuf metadata to fetch type from.
+
+    Returns:
+        Enum value corresponding to the protobuf message.
+    """
+    # ComponentType values in the protobuf definition are not unique across categories
+    # as of v0.11.0, so we need to check the component category first, before doing any
+    # component type checks.
+    if (
+        component_category
+        == components_pb.ComponentCategory.COMPONENT_CATEGORY_INVERTER
+    ):
+        # mypy 1.4.1 crashes at this line, maybe it doesn't like the name of the "type"
+        # attribute in this context.  Hence the "# type: ignore".
+        if not any(
+            t.value == component_metadata.type for t in InverterType  # type: ignore
+        ):
+            return None
+
+        return InverterType(component_metadata.type)
+
+    return None
+
+
+class ComponentCategory(Enum):
+    """Possible types of microgrid component."""
+
+    NONE = components_pb.ComponentCategory.COMPONENT_CATEGORY_UNSPECIFIED
+    """Unspecified component category."""
+
+    GRID = components_pb.ComponentCategory.COMPONENT_CATEGORY_GRID
+    """Grid component."""
+
+    METER = components_pb.ComponentCategory.COMPONENT_CATEGORY_METER
+    """Meter component."""
+
+    INVERTER = components_pb.ComponentCategory.COMPONENT_CATEGORY_INVERTER
+    """Inverter component."""
+
+    BATTERY = components_pb.ComponentCategory.COMPONENT_CATEGORY_BATTERY
+    """Battery component."""
+
+    EV_CHARGER = components_pb.ComponentCategory.COMPONENT_CATEGORY_EV_CHARGER
+    """EV charger component."""
+
+    CHP = components_pb.ComponentCategory.COMPONENT_CATEGORY_CHP
+    """CHP component."""
+
+
+def _component_category_from_protobuf(
+    component_category: components_pb.ComponentCategory.ValueType,
+) -> ComponentCategory:
+    """Convert a protobuf ComponentCategory message to ComponentCategory enum.
+
+    For internal-only use by the `microgrid` package.
+
+    Args:
+        component_category: protobuf enum to convert
+
+    Returns:
+        Enum value corresponding to the protobuf message.
+
+    Raises:
+        ValueError: if `component_category` is a sensor (this is not considered
+            a valid component category as it does not form part of the
+            microgrid itself)
+    """
+    if component_category == components_pb.ComponentCategory.COMPONENT_CATEGORY_SENSOR:
+        raise ValueError("Cannot create a component from a sensor!")
+
+    if not any(t.value == component_category for t in ComponentCategory):
+        return ComponentCategory.NONE
+
+    return ComponentCategory(component_category)
+
+
+@dataclass(frozen=True)
+class ComponentMetadata:
+    """Base class for component metadata classes."""
+
+    fuse: Fuse | None = None
+    """The fuse at the grid connection point."""
+
+
+@dataclass(frozen=True)
+class GridMetadata(ComponentMetadata):
+    """Metadata for a grid connection point."""
+
+
+def _component_metadata_from_protobuf(
+    component_category: components_pb.ComponentCategory.ValueType,
+    component_metadata: grid_pb.Metadata,
+) -> GridMetadata | None:
+    from ...timeseries import Current, Fuse  # pylint: disable=import-outside-toplevel
+
+    if component_category == components_pb.ComponentCategory.COMPONENT_CATEGORY_GRID:
+        max_current = Current.from_amperes(component_metadata.rated_fuse_current)
+        fuse = Fuse(max_current)
+        return GridMetadata(fuse)
+
+    return None
+
+
+@dataclass(frozen=True)
+class Component:
+    """Metadata for a single microgrid component."""
+
+    component_id: int
+    """The ID of this component."""
+
+    category: ComponentCategory
+    """The category of this component."""
+
+    type: ComponentType | None = None
+    """The type of this component."""
+
+    metadata: ComponentMetadata | None = None
+    """The metadata of this component."""
+
+    def is_valid(self) -> bool:
+        """Check if this instance contains valid data.
+
+        Returns:
+            `True` if `id > 0` and `type` is a valid `ComponentCategory`, or if `id
+                == 0` and `type` is `GRID`, `False` otherwise
+        """
+        return (
+            self.component_id > 0 and any(t == self.category for t in ComponentCategory)
+        ) or (self.component_id == 0 and self.category == ComponentCategory.GRID)
+
+    def __hash__(self) -> int:
+        """Compute a hash of this instance, obtained by hashing the `component_id` field.
+
+        Returns:
+            Hash of this instance.
+        """
+        return hash(self.component_id)
+
+
+class ComponentMetricId(Enum):
+    """An enum representing the various metrics available in the microgrid."""
+
+    ACTIVE_POWER = "active_power"
+    """Active power."""
+
+    ACTIVE_POWER_PHASE_1 = "active_power_phase_1"
+    """Active power in phase 1."""
+    ACTIVE_POWER_PHASE_2 = "active_power_phase_2"
+    """Active power in phase 2."""
+    ACTIVE_POWER_PHASE_3 = "active_power_phase_3"
+    """Active power in phase 3."""
+
+    CURRENT_PHASE_1 = "current_phase_1"
+    """Current in phase 1."""
+    CURRENT_PHASE_2 = "current_phase_2"
+    """Current in phase 2."""
+    CURRENT_PHASE_3 = "current_phase_3"
+    """Current in phase 3."""
+
+    VOLTAGE_PHASE_1 = "voltage_phase_1"
+    """Voltage in phase 1."""
+    VOLTAGE_PHASE_2 = "voltage_phase_2"
+    """Voltage in phase 2."""
+    VOLTAGE_PHASE_3 = "voltage_phase_3"
+    """Voltage in phase 3."""
+
+    FREQUENCY = "frequency"
+
+    SOC = "soc"
+    """State of charge."""
+    SOC_LOWER_BOUND = "soc_lower_bound"
+    """Lower bound of state of charge."""
+    SOC_UPPER_BOUND = "soc_upper_bound"
+    """Upper bound of state of charge."""
+    CAPACITY = "capacity"
+    """Capacity."""
+
+    POWER_INCLUSION_LOWER_BOUND = "power_inclusion_lower_bound"
+    """Power inclusion lower bound."""
+    POWER_EXCLUSION_LOWER_BOUND = "power_exclusion_lower_bound"
+    """Power exclusion lower bound."""
+    POWER_EXCLUSION_UPPER_BOUND = "power_exclusion_upper_bound"
+    """Power exclusion upper bound."""
+    POWER_INCLUSION_UPPER_BOUND = "power_inclusion_upper_bound"
+    """Power inclusion upper bound."""
+
+    ACTIVE_POWER_INCLUSION_LOWER_BOUND = "active_power_inclusion_lower_bound"
+    """Active power inclusion lower bound."""
+    ACTIVE_POWER_EXCLUSION_LOWER_BOUND = "active_power_exclusion_lower_bound"
+    """Active power exclusion lower bound."""
+    ACTIVE_POWER_EXCLUSION_UPPER_BOUND = "active_power_exclusion_upper_bound"
+    """Active power exclusion upper bound."""
+    ACTIVE_POWER_INCLUSION_UPPER_BOUND = "active_power_inclusion_upper_bound"
+    """Active power inclusion upper bound."""
+
+    TEMPERATURE = "temperature"
+    """Temperature."""

--- a/src/frequenz/client/microgrid/_component_data.py
+++ b/src/frequenz/client/microgrid/_component_data.py
@@ -1,0 +1,487 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Component data types for data coming from a microgrid."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+import frequenz.api.microgrid.battery_pb2 as battery_pb
+import frequenz.api.microgrid.inverter_pb2 as inverter_pb
+import frequenz.api.microgrid.microgrid_pb2 as microgrid_pb
+
+from ._component_states import EVChargerCableState, EVChargerComponentState
+
+
+@dataclass(frozen=True)
+class ComponentData(ABC):
+    """A private base class for strongly typed component data classes."""
+
+    component_id: int
+    """The ID identifying this component in the microgrid."""
+
+    timestamp: datetime
+    """The timestamp of when the data was measured."""
+
+    # The `raw` attribute is excluded from the constructor as it can only be provided
+    # when instantiating `ComponentData` using the `from_proto` method, which reads
+    # data from a protobuf message. The whole protobuf message is stored as the `raw`
+    # attribute. When `ComponentData` is not instantiated from a protobuf message,
+    # i.e. using the constructor, `raw` will be set to `None`.
+    raw: microgrid_pb.ComponentData | None = field(default=None, init=False)
+    """Raw component data as decoded from the wire."""
+
+    def _set_raw(self, raw: microgrid_pb.ComponentData) -> None:
+        """Store raw protobuf message.
+
+        It is preferred to keep the dataclasses immutable (frozen) and make the `raw`
+            attribute read-only, which is why the approach of writing to `__dict__`
+            was used, instead of mutating the `self.raw = raw` attribute directly.
+
+        Args:
+            raw: raw component data as decoded from the wire.
+        """
+        self.__dict__["raw"] = raw
+
+    @classmethod
+    @abstractmethod
+    def from_proto(cls, raw: microgrid_pb.ComponentData) -> ComponentData:
+        """Create ComponentData from a protobuf message.
+
+        Args:
+            raw: raw component data as decoded from the wire.
+
+        Returns:
+            The instance created from the protobuf message.
+        """
+
+
+@dataclass(frozen=True)
+class MeterData(ComponentData):
+    """A wrapper class for holding meter data."""
+
+    active_power: float
+    """The 3-phase active power, in Watts, represented in the passive sign convention.
+            +ve current means consumption, away from the grid.
+            -ve current means supply into the grid.
+    """
+
+    active_power_per_phase: tuple[float, float, float]
+    """The AC active power for phase/line 1,2 and 3 respectively."""
+
+    current_per_phase: tuple[float, float, float]
+    """AC current in Amperes (A) for phase/line 1,2 and 3 respectively.
+            +ve current means consumption, away from the grid.
+            -ve current means supply into the grid.
+    """
+
+    voltage_per_phase: tuple[float, float, float]
+    """The ac voltage in volts (v) between the line and the neutral wire for phase/line
+        1,2 and 3 respectively.
+    """
+
+    frequency: float
+    """The AC power frequency in Hertz (Hz)."""
+
+    @classmethod
+    def from_proto(cls, raw: microgrid_pb.ComponentData) -> MeterData:
+        """Create MeterData from a protobuf message.
+
+        Args:
+            raw: raw component data as decoded from the wire.
+
+        Returns:
+            Instance of MeterData created from the protobuf message.
+        """
+        meter_data = cls(
+            component_id=raw.id,
+            timestamp=raw.ts.ToDatetime(tzinfo=timezone.utc),
+            active_power=raw.meter.data.ac.power_active.value,
+            active_power_per_phase=(
+                raw.meter.data.ac.phase_1.power_active.value,
+                raw.meter.data.ac.phase_2.power_active.value,
+                raw.meter.data.ac.phase_3.power_active.value,
+            ),
+            current_per_phase=(
+                raw.meter.data.ac.phase_1.current.value,
+                raw.meter.data.ac.phase_2.current.value,
+                raw.meter.data.ac.phase_3.current.value,
+            ),
+            voltage_per_phase=(
+                raw.meter.data.ac.phase_1.voltage.value,
+                raw.meter.data.ac.phase_2.voltage.value,
+                raw.meter.data.ac.phase_3.voltage.value,
+            ),
+            frequency=raw.meter.data.ac.frequency.value,
+        )
+        meter_data._set_raw(raw=raw)
+        return meter_data
+
+
+@dataclass(frozen=True)
+class BatteryData(ComponentData):
+    """A wrapper class for holding battery data."""
+
+    soc: float
+    """Battery's overall SoC in percent (%)."""
+
+    soc_lower_bound: float
+    """The SoC below which discharge commands will be blocked by the system,
+        in percent (%).
+    """
+
+    soc_upper_bound: float
+    """The SoC above which charge commands will be blocked by the system,
+        in percent (%).
+    """
+
+    capacity: float
+    """The capacity of the battery in Wh (Watt-hour)."""
+
+    # pylint: disable=line-too-long
+    power_inclusion_lower_bound: float
+    """Lower inclusion bound for battery power in watts.
+
+    This is the lower limit of the range within which power requests are allowed for the
+    battery.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    power_exclusion_lower_bound: float
+    """Lower exclusion bound for battery power in watts.
+
+    This is the lower limit of the range within which power requests are not allowed for
+    the battery.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    power_inclusion_upper_bound: float
+    """Upper inclusion bound for battery power in watts.
+
+    This is the upper limit of the range within which power requests are allowed for the
+    battery.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    power_exclusion_upper_bound: float
+    """Upper exclusion bound for battery power in watts.
+
+    This is the upper limit of the range within which power requests are not allowed for
+    the battery.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+    # pylint: enable=line-too-long
+
+    temperature: float
+    """The (average) temperature reported by the battery, in Celsius (°C)."""
+
+    _relay_state: battery_pb.RelayState.ValueType
+    """State of the battery relay."""
+
+    _component_state: battery_pb.ComponentState.ValueType
+    """State of the battery."""
+
+    _errors: list[battery_pb.Error]
+    """List of errors in protobuf struct."""
+
+    @classmethod
+    def from_proto(cls, raw: microgrid_pb.ComponentData) -> BatteryData:
+        """Create BatteryData from a protobuf message.
+
+        Args:
+            raw: raw component data as decoded from the wire.
+
+        Returns:
+            Instance of BatteryData created from the protobuf message.
+        """
+        raw_power = raw.battery.data.dc.power
+        battery_data = cls(
+            component_id=raw.id,
+            timestamp=raw.ts.ToDatetime(tzinfo=timezone.utc),
+            soc=raw.battery.data.soc.avg,
+            soc_lower_bound=raw.battery.data.soc.system_inclusion_bounds.lower,
+            soc_upper_bound=raw.battery.data.soc.system_inclusion_bounds.upper,
+            capacity=raw.battery.properties.capacity,
+            power_inclusion_lower_bound=raw_power.system_inclusion_bounds.lower,
+            power_exclusion_lower_bound=raw_power.system_exclusion_bounds.lower,
+            power_inclusion_upper_bound=raw_power.system_inclusion_bounds.upper,
+            power_exclusion_upper_bound=raw_power.system_exclusion_bounds.upper,
+            temperature=raw.battery.data.temperature.avg,
+            _relay_state=raw.battery.state.relay_state,
+            _component_state=raw.battery.state.component_state,
+            _errors=list(raw.battery.errors),
+        )
+        battery_data._set_raw(raw=raw)
+        return battery_data
+
+
+@dataclass(frozen=True)
+class InverterData(ComponentData):
+    """A wrapper class for holding inverter data."""
+
+    active_power: float
+    """The 3-phase active power, in Watts, represented in the passive sign convention.
+            +ve current means consumption, away from the grid.
+            -ve current means supply into the grid.
+    """
+
+    active_power_per_phase: tuple[float, float, float]
+    """The AC active power for phase/line 1, 2 and 3 respectively."""
+
+    current_per_phase: tuple[float, float, float]
+    """AC current in Amperes (A) for phase/line 1, 2 and 3 respectively.
+            +ve current means consumption, away from the grid.
+            -ve current means supply into the grid.
+    """
+
+    voltage_per_phase: tuple[float, float, float]
+    """The AC voltage in Volts (V) between the line and the neutral wire for
+       phase/line 1, 2 and 3 respectively.
+    """
+
+    # pylint: disable=line-too-long
+    active_power_inclusion_lower_bound: float
+    """Lower inclusion bound for inverter power in watts.
+
+    This is the lower limit of the range within which power requests are allowed for the
+    inverter.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    active_power_exclusion_lower_bound: float
+    """Lower exclusion bound for inverter power in watts.
+
+    This is the lower limit of the range within which power requests are not allowed for
+    the inverter.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    active_power_inclusion_upper_bound: float
+    """Upper inclusion bound for inverter power in watts.
+
+    This is the upper limit of the range within which power requests are allowed for the
+    inverter.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    active_power_exclusion_upper_bound: float
+    """Upper exclusion bound for inverter power in watts.
+
+    This is the upper limit of the range within which power requests are not allowed for
+    the inverter.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+    # pylint: enable=line-too-long
+
+    frequency: float
+    """AC frequency, in Hertz (Hz)."""
+
+    _component_state: inverter_pb.ComponentState.ValueType
+    """State of the inverter."""
+
+    _errors: list[inverter_pb.Error]
+    """List of errors from the component."""
+
+    @classmethod
+    def from_proto(cls, raw: microgrid_pb.ComponentData) -> InverterData:
+        """Create InverterData from a protobuf message.
+
+        Args:
+            raw: raw component data as decoded from the wire.
+
+        Returns:
+            Instance of InverterData created from the protobuf message.
+        """
+        raw_power = raw.inverter.data.ac.power_active
+        inverter_data = cls(
+            component_id=raw.id,
+            timestamp=raw.ts.ToDatetime(tzinfo=timezone.utc),
+            active_power=raw.inverter.data.ac.power_active.value,
+            active_power_per_phase=(
+                raw.inverter.data.ac.phase_1.power_active.value,
+                raw.inverter.data.ac.phase_2.power_active.value,
+                raw.inverter.data.ac.phase_3.power_active.value,
+            ),
+            current_per_phase=(
+                raw.inverter.data.ac.phase_1.current.value,
+                raw.inverter.data.ac.phase_2.current.value,
+                raw.inverter.data.ac.phase_3.current.value,
+            ),
+            voltage_per_phase=(
+                raw.inverter.data.ac.phase_1.voltage.value,
+                raw.inverter.data.ac.phase_2.voltage.value,
+                raw.inverter.data.ac.phase_3.voltage.value,
+            ),
+            active_power_inclusion_lower_bound=raw_power.system_inclusion_bounds.lower,
+            active_power_exclusion_lower_bound=raw_power.system_exclusion_bounds.lower,
+            active_power_inclusion_upper_bound=raw_power.system_inclusion_bounds.upper,
+            active_power_exclusion_upper_bound=raw_power.system_exclusion_bounds.upper,
+            frequency=raw.inverter.data.ac.frequency.value,
+            _component_state=raw.inverter.state.component_state,
+            _errors=list(raw.inverter.errors),
+        )
+
+        inverter_data._set_raw(raw=raw)
+        return inverter_data
+
+
+@dataclass(frozen=True)
+class EVChargerData(ComponentData):
+    """A wrapper class for holding ev_charger data."""
+
+    active_power: float
+    """The 3-phase active power, in Watts, represented in the passive sign convention.
+        +ve current means consumption, away from the grid.
+        -ve current means supply into the grid.
+    """
+
+    active_power_per_phase: tuple[float, float, float]
+    """The AC active power for phase/line 1,2 and 3 respectively."""
+
+    current_per_phase: tuple[float, float, float]
+    """AC current in Amperes (A) for phase/line 1,2 and 3 respectively.
+        +ve current means consumption, away from the grid.
+        -ve current means supply into the grid.
+    """
+
+    voltage_per_phase: tuple[float, float, float]
+    """The AC voltage in Volts (V) between the line and the neutral
+        wire for phase/line 1,2 and 3 respectively.
+    """
+
+    active_power_inclusion_lower_bound: float
+    """Lower inclusion bound for EV charger power in watts.
+
+    This is the lower limit of the range within which power requests are allowed for the
+    EV charger.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    active_power_exclusion_lower_bound: float
+    """Lower exclusion bound for EV charger power in watts.
+
+    This is the lower limit of the range within which power requests are not allowed for
+    the EV charger.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    active_power_inclusion_upper_bound: float
+    """Upper inclusion bound for EV charger power in watts.
+
+    This is the upper limit of the range within which power requests are allowed for the
+    EV charger.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    active_power_exclusion_upper_bound: float
+    """Upper exclusion bound for EV charger power in watts.
+
+    This is the upper limit of the range within which power requests are not allowed for
+    the EV charger.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    frequency: float
+    """AC frequency, in Hertz (Hz)."""
+
+    cable_state: EVChargerCableState
+    """The state of the ev charger's cable."""
+
+    component_state: EVChargerComponentState
+    """The state of the ev charger."""
+
+    @classmethod
+    def from_proto(cls, raw: microgrid_pb.ComponentData) -> EVChargerData:
+        """Create EVChargerData from a protobuf message.
+
+        Args:
+            raw: raw component data as decoded from the wire.
+
+        Returns:
+            Instance of EVChargerData created from the protobuf message.
+        """
+        raw_power = raw.ev_charger.data.ac.power_active
+        ev_charger_data = cls(
+            component_id=raw.id,
+            timestamp=raw.ts.ToDatetime(tzinfo=timezone.utc),
+            active_power=raw_power.value,
+            active_power_per_phase=(
+                raw.ev_charger.data.ac.phase_1.power_active.value,
+                raw.ev_charger.data.ac.phase_2.power_active.value,
+                raw.ev_charger.data.ac.phase_3.power_active.value,
+            ),
+            current_per_phase=(
+                raw.ev_charger.data.ac.phase_1.current.value,
+                raw.ev_charger.data.ac.phase_2.current.value,
+                raw.ev_charger.data.ac.phase_3.current.value,
+            ),
+            voltage_per_phase=(
+                raw.ev_charger.data.ac.phase_1.voltage.value,
+                raw.ev_charger.data.ac.phase_2.voltage.value,
+                raw.ev_charger.data.ac.phase_3.voltage.value,
+            ),
+            active_power_inclusion_lower_bound=raw_power.system_inclusion_bounds.lower,
+            active_power_exclusion_lower_bound=raw_power.system_exclusion_bounds.lower,
+            active_power_inclusion_upper_bound=raw_power.system_inclusion_bounds.upper,
+            active_power_exclusion_upper_bound=raw_power.system_exclusion_bounds.upper,
+            cable_state=EVChargerCableState.from_pb(raw.ev_charger.state.cable_state),
+            component_state=EVChargerComponentState.from_pb(
+                raw.ev_charger.state.component_state
+            ),
+            frequency=raw.ev_charger.data.ac.frequency.value,
+        )
+        ev_charger_data._set_raw(raw=raw)
+        return ev_charger_data
+
+    def is_ev_connected(self) -> bool:
+        """Check whether an EV is connected to the charger.
+
+        Returns:
+            When the charger is not in an error state, whether an EV is connected to
+                the charger.
+        """
+        return self.component_state not in (
+            EVChargerComponentState.AUTHORIZATION_REJECTED,
+            EVChargerComponentState.ERROR,
+        ) and self.cable_state in (
+            EVChargerCableState.EV_LOCKED,
+            EVChargerCableState.EV_PLUGGED,
+        )

--- a/src/frequenz/client/microgrid/_component_data.py
+++ b/src/frequenz/client/microgrid/_component_data.py
@@ -121,7 +121,7 @@ class MeterData(ComponentData):
 
 
 @dataclass(frozen=True)
-class BatteryData(ComponentData):
+class BatteryData(ComponentData):  # pylint: disable=too-many-instance-attributes
     """A wrapper class for holding battery data."""
 
     soc: float
@@ -230,7 +230,7 @@ class BatteryData(ComponentData):
 
 
 @dataclass(frozen=True)
-class InverterData(ComponentData):
+class InverterData(ComponentData):  # pylint: disable=too-many-instance-attributes
     """A wrapper class for holding inverter data."""
 
     active_power: float
@@ -352,7 +352,7 @@ class InverterData(ComponentData):
 
 
 @dataclass(frozen=True)
-class EVChargerData(ComponentData):
+class EVChargerData(ComponentData):  # pylint: disable=too-many-instance-attributes
     """A wrapper class for holding ev_charger data."""
 
     active_power: float

--- a/src/frequenz/client/microgrid/_component_states.py
+++ b/src/frequenz/client/microgrid/_component_states.py
@@ -1,0 +1,104 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Defines states of components that can be used in a microgrid."""
+from __future__ import annotations
+
+from enum import Enum
+
+from frequenz.api.microgrid import ev_charger_pb2 as ev_charger_pb
+
+# pylint: disable=no-member
+
+
+class EVChargerCableState(Enum):
+    """Cable states of an EV Charger."""
+
+    UNSPECIFIED = ev_charger_pb.CableState.CABLE_STATE_UNSPECIFIED
+    """Unspecified cable state."""
+
+    UNPLUGGED = ev_charger_pb.CableState.CABLE_STATE_UNPLUGGED
+    """The cable is unplugged."""
+
+    CHARGING_STATION_PLUGGED = (
+        ev_charger_pb.CableState.CABLE_STATE_CHARGING_STATION_PLUGGED
+    )
+    """The cable is plugged into the charging station."""
+
+    CHARGING_STATION_LOCKED = (
+        ev_charger_pb.CableState.CABLE_STATE_CHARGING_STATION_LOCKED
+    )
+    """The cable is plugged into the charging station and locked."""
+
+    EV_PLUGGED = ev_charger_pb.CableState.CABLE_STATE_EV_PLUGGED
+    """The cable is plugged into the EV."""
+
+    EV_LOCKED = ev_charger_pb.CableState.CABLE_STATE_EV_LOCKED
+    """The cable is plugged into the EV and locked."""
+
+    @classmethod
+    def from_pb(
+        cls, evc_state: ev_charger_pb.CableState.ValueType
+    ) -> EVChargerCableState:
+        """Convert a protobuf CableState value to EVChargerCableState enum.
+
+        Args:
+            evc_state: protobuf cable state to convert.
+
+        Returns:
+            Enum value corresponding to the protobuf message.
+        """
+        if not any(t.value == evc_state for t in EVChargerCableState):
+            return cls.UNSPECIFIED
+
+        return EVChargerCableState(evc_state)
+
+
+class EVChargerComponentState(Enum):
+    """Component State of an EV Charger."""
+
+    UNSPECIFIED = ev_charger_pb.ComponentState.COMPONENT_STATE_UNSPECIFIED
+    """Unspecified component state."""
+
+    STARTING = ev_charger_pb.ComponentState.COMPONENT_STATE_STARTING
+    """The component is starting."""
+
+    NOT_READY = ev_charger_pb.ComponentState.COMPONENT_STATE_NOT_READY
+    """The component is not ready."""
+
+    READY = ev_charger_pb.ComponentState.COMPONENT_STATE_READY
+    """The component is ready."""
+
+    CHARGING = ev_charger_pb.ComponentState.COMPONENT_STATE_CHARGING
+    """The component is charging."""
+
+    DISCHARGING = ev_charger_pb.ComponentState.COMPONENT_STATE_DISCHARGING
+    """The component is discharging."""
+
+    ERROR = ev_charger_pb.ComponentState.COMPONENT_STATE_ERROR
+    """The component is in error state."""
+
+    AUTHORIZATION_REJECTED = (
+        ev_charger_pb.ComponentState.COMPONENT_STATE_AUTHORIZATION_REJECTED
+    )
+    """The component rejected authorization."""
+
+    INTERRUPTED = ev_charger_pb.ComponentState.COMPONENT_STATE_INTERRUPTED
+    """The component is interrupted."""
+
+    @classmethod
+    def from_pb(
+        cls, evc_state: ev_charger_pb.ComponentState.ValueType
+    ) -> EVChargerComponentState:
+        """Convert a protobuf ComponentState value to EVChargerComponentState enum.
+
+        Args:
+            evc_state: protobuf component state to convert.
+
+        Returns:
+            Enum value corresponding to the protobuf message.
+        """
+        if not any(t.value == evc_state for t in EVChargerComponentState):
+            return cls.UNSPECIFIED
+
+        return EVChargerComponentState(evc_state)

--- a/src/frequenz/client/microgrid/_connection.py
+++ b/src/frequenz/client/microgrid/_connection.py
@@ -1,0 +1,25 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Defines the connections between microgrid components."""
+
+from typing import NamedTuple
+
+
+class Connection(NamedTuple):
+    """Metadata for a connection between microgrid components."""
+
+    start: int
+    """The component ID that represents the start component of the connection."""
+
+    end: int
+    """The component ID that represents the end component of the connection."""
+
+    def is_valid(self) -> bool:
+        """Check if this instance contains valid data.
+
+        Returns:
+            `True` if `start >= 0`, `end > 0`, and `start != end`, `False`
+                otherwise.
+        """
+        return self.start >= 0 and self.end > 0 and self.start != self.end

--- a/src/frequenz/client/microgrid/_constants.py
+++ b/src/frequenz/client/microgrid/_constants.py
@@ -1,0 +1,21 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Module with constants shared between instances of the sdk.
+
+To be replaced by ConfigManager.
+"""
+
+RECEIVER_MAX_SIZE = 50
+"""Default buffer size of the receiver."""
+
+WAIT_FOR_COMPONENT_DATA_SEC: float = 2
+"""Delay the start of the application to wait for the data."""
+
+MAX_BATTERY_DATA_AGE_SEC: float = 2
+"""Max time difference for the battery or inverter data to be considered as reliable.
+
+If battery or inverter stopped sending data, then this is the maximum time when its
+last message should be considered as valid. After that time, component data
+should not be used.
+"""

--- a/src/frequenz/client/microgrid/_retry.py
+++ b/src/frequenz/client/microgrid/_retry.py
@@ -1,0 +1,169 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Implementations for retry strategies."""
+
+from __future__ import annotations
+
+import random
+from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from copy import deepcopy
+
+DEFAULT_RETRY_INTERVAL = 3.0
+"""Default retry interval, in seconds."""
+
+DEFAULT_RETRY_JITTER = 1.0
+"""Default retry jitter, in seconds."""
+
+
+class RetryStrategy(ABC):
+    """Interface for implementing retry strategies."""
+
+    _limit: int | None
+    _count: int
+
+    @abstractmethod
+    def next_interval(self) -> float | None:
+        """Return the time to wait before the next retry.
+
+        Returns `None` if the retry limit has been reached, and no more retries
+        are possible.
+
+        Returns:
+            Time until next retry when below retry limit, and None otherwise.
+        """
+
+    def get_progress(self) -> str:
+        """Return a string denoting the retry progress.
+
+        Returns:
+            String denoting retry progress in the form "(count/limit)"
+        """
+        if self._limit is None:
+            return f"({self._count}/∞)"
+
+        return f"({self._count}/{self._limit})"
+
+    def reset(self) -> None:
+        """Reset the retry counter.
+
+        To be called as soon as a connection is successful.
+        """
+        self._count = 0
+
+    def copy(self) -> RetryStrategy:
+        """Create a new instance of `self`.
+
+        Returns:
+            A deepcopy of `self`.
+        """
+        ret = deepcopy(self)
+        ret.reset()
+        return ret
+
+    def __iter__(self) -> Iterator[float]:
+        """Return an iterator over the retry intervals.
+
+        Yields:
+            Next retry interval in seconds.
+        """
+        while True:
+            interval = self.next_interval()
+            if interval is None:
+                break
+            yield interval
+
+
+class LinearBackoff(RetryStrategy):
+    """Provides methods for calculating the interval between retries."""
+
+    def __init__(
+        self,
+        interval: float = DEFAULT_RETRY_INTERVAL,
+        jitter: float = DEFAULT_RETRY_JITTER,
+        limit: int | None = None,
+    ) -> None:
+        """Create a `LinearBackoff` instance.
+
+        Args:
+            interval: time to wait for before the next retry, in seconds.
+            jitter: a jitter to add to the retry interval.
+            limit: max number of retries before giving up.  `None` means no
+                limit, and `0` means no retry.
+        """
+        self._interval = interval
+        self._jitter = jitter
+        self._limit = limit
+
+        self._count = 0
+
+    def next_interval(self) -> float | None:
+        """Return the time to wait before the next retry.
+
+        Returns `None` if the retry limit has been reached, and no more retries
+        are possible.
+
+        Returns:
+            Time until next retry when below retry limit, and None otherwise.
+        """
+        if self._limit is not None and self._count >= self._limit:
+            return None
+        self._count += 1
+        return self._interval + random.uniform(0.0, self._jitter)
+
+
+class ExponentialBackoff(RetryStrategy):
+    """Provides methods for calculating the exponential interval between retries."""
+
+    DEFAULT_INTERVAL = DEFAULT_RETRY_INTERVAL
+    """Default retry interval, in seconds."""
+
+    DEFAULT_MAX_INTERVAL = 60.0
+    """Default maximum retry interval, in seconds."""
+
+    DEFAULT_MULTIPLIER = 2.0
+    """Default multiplier for exponential increment."""
+
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        initial_interval: float = DEFAULT_INTERVAL,
+        max_interval: float = DEFAULT_MAX_INTERVAL,
+        multiplier: float = DEFAULT_MULTIPLIER,
+        jitter: float = DEFAULT_RETRY_JITTER,
+        limit: int | None = None,
+    ) -> None:
+        """Create a `ExponentialBackoff` instance.
+
+        Args:
+            initial_interval: time to wait for before the first retry, in
+                seconds.
+            max_interval: maximum interval, in seconds.
+            multiplier: exponential increment for interval.
+            jitter: a jitter to add to the retry interval.
+            limit: max number of retries before giving up.  `None` means no
+                limit, and `0` means no retry.
+        """
+        self._initial = initial_interval
+        self._max = max_interval
+        self._multiplier = multiplier
+        self._jitter = jitter
+        self._limit = limit
+
+        self._count = 0
+
+    def next_interval(self) -> float | None:
+        """Return the time to wait before the next retry.
+
+        Returns `None` if the retry limit has been reached, and no more retries
+        are possible.
+
+        Returns:
+            Time until next retry when below retry limit, and None otherwise.
+        """
+        if self._limit is not None and self._count >= self._limit:
+            return None
+        self._count += 1
+        exp_backoff_interval = self._initial * self._multiplier ** (self._count - 1)
+        return min(exp_backoff_interval + random.uniform(0.0, self._jitter), self._max)

--- a/src/frequenz/client/microgrid/metadata.py
+++ b/src/frequenz/client/microgrid/metadata.py
@@ -1,0 +1,50 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Metadata that describes a microgrid."""
+
+from dataclasses import dataclass
+from zoneinfo import ZoneInfo
+
+from timezonefinder import TimezoneFinder
+
+_timezone_finder = TimezoneFinder()
+
+
+@dataclass(frozen=True, kw_only=True)
+class Location:
+    """Metadata for the location of microgrid."""
+
+    latitude: float | None = None
+    """The latitude of the microgrid in degree."""
+
+    longitude: float | None = None
+    """The longitude of the microgrid in degree."""
+
+    timezone: ZoneInfo | None = None
+    """The timezone of the microgrid.
+
+    The timezone will be set to None if the latitude or longitude points
+    are not set or the timezone cannot be found given the location points.
+    """
+
+    def __post_init__(self) -> None:
+        """Initialize the timezone of the microgrid."""
+        if self.latitude is None or self.longitude is None or self.timezone is not None:
+            return
+
+        timezone = _timezone_finder.timezone_at(lat=self.latitude, lng=self.longitude)
+        if timezone:
+            # The dataclass is frozen, so it needs to use __setattr__ to set the timezone.
+            object.__setattr__(self, "timezone", ZoneInfo(key=timezone))
+
+
+@dataclass(frozen=True, kw_only=True)
+class Metadata:
+    """Metadata for the microgrid."""
+
+    microgrid_id: int | None = None
+    """The ID of the microgrid."""
+
+    location: Location | None = None
+    """The location of the microgrid."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,6 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for the Microgrid API client."""
+
+# This is needed just so we can do local imports in the tests.

--- a/tests/mock_api.py
+++ b/tests/mock_api.py
@@ -1,0 +1,329 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Mock implementation of the microgrid gRPC API.
+
+This is intended to support the narrow set of test cases that have to
+check integration with the API.  Note that this should exclude almost
+all framework code, as API integration should be highly encapsulated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable, Iterator
+
+# pylint: disable=invalid-name,no-name-in-module,unused-import
+from concurrent import futures
+
+import grpc
+from frequenz.api.common.components_pb2 import (
+    COMPONENT_CATEGORY_BATTERY,
+    COMPONENT_CATEGORY_EV_CHARGER,
+    COMPONENT_CATEGORY_INVERTER,
+    COMPONENT_CATEGORY_METER,
+    ComponentCategory,
+    InverterType,
+)
+from frequenz.api.common.metrics.electrical_pb2 import AC
+from frequenz.api.common.metrics_pb2 import Metric, MetricAggregation
+from frequenz.api.microgrid.battery_pb2 import Battery
+from frequenz.api.microgrid.battery_pb2 import Data as BatteryData
+from frequenz.api.microgrid.ev_charger_pb2 import EvCharger
+from frequenz.api.microgrid.grid_pb2 import Metadata as GridMetadata
+from frequenz.api.microgrid.inverter_pb2 import Inverter
+from frequenz.api.microgrid.inverter_pb2 import Metadata as InverterMetadata
+from frequenz.api.microgrid.meter_pb2 import Data as MeterData
+from frequenz.api.microgrid.meter_pb2 import Meter
+from frequenz.api.microgrid.microgrid_pb2 import (
+    Component,
+    ComponentData,
+    ComponentFilter,
+    ComponentIdParam,
+    ComponentList,
+    Connection,
+    ConnectionFilter,
+    ConnectionList,
+    MicrogridMetadata,
+    SetBoundsParam,
+    SetPowerActiveParam,
+    SetPowerReactiveParam,
+)
+from frequenz.api.microgrid.microgrid_pb2_grpc import (
+    MicrogridServicer,
+    add_MicrogridServicer_to_server,
+)
+from google.protobuf.empty_pb2 import Empty
+from google.protobuf.timestamp_pb2 import Timestamp
+from google.protobuf.wrappers_pb2 import BoolValue
+
+from frequenz.sdk.timeseries import Current
+
+
+class MockMicrogridServicer(  # pylint: disable=too-many-public-methods
+    MicrogridServicer
+):
+    """Servicer implementation mock for the microgrid API.
+
+    This class implements customizable mocks of the individual API methods,
+    and can be bound to a gRPC server instance to create the complete API
+    mock.
+    """
+
+    def __init__(
+        self,
+        components: list[tuple[int, ComponentCategory.V]] | None = None,
+        connections: list[tuple[int, int]] | None = None,
+    ) -> None:
+        """Create a MockMicrogridServicer instance."""
+        self._components: list[Component] = []
+        self._connections: list[Connection] = []
+        self._bounds: list[SetBoundsParam] = []
+
+        if components is not None:
+            self.set_components(components)
+        if connections is not None:
+            self.set_connections(connections)
+
+        self._latest_power: SetPowerActiveParam | None = None
+
+    def add_component(
+        self,
+        component_id: int,
+        component_category: ComponentCategory.V,
+        max_current: Current | None = None,
+        inverter_type: InverterType.V = InverterType.INVERTER_TYPE_UNSPECIFIED,
+    ) -> None:
+        """Add a component to the mock service."""
+        if component_category == ComponentCategory.COMPONENT_CATEGORY_INVERTER:
+            self._components.append(
+                Component(
+                    id=component_id,
+                    category=component_category,
+                    inverter=InverterMetadata(type=inverter_type),
+                )
+            )
+        elif (
+            component_category == ComponentCategory.COMPONENT_CATEGORY_GRID
+            and max_current is not None
+        ):
+            self._components.append(
+                Component(
+                    id=component_id,
+                    category=component_category,
+                    grid=GridMetadata(rated_fuse_current=int(max_current.as_amperes())),
+                )
+            )
+        else:
+            self._components.append(
+                Component(id=component_id, category=component_category)
+            )
+
+    def add_connection(self, start: int, end: int) -> None:
+        """Add a connection to the mock service."""
+        self._connections.append(Connection(start=start, end=end))
+
+    def set_components(self, components: list[tuple[int, ComponentCategory.V]]) -> None:
+        """Set components to mock service, dropping existing."""
+        self._components.clear()
+        self._components.extend(
+            map(lambda c: Component(id=c[0], category=c[1]), components)
+        )
+
+    def set_connections(self, connections: list[tuple[int, int]]) -> None:
+        """Set connections to mock service, dropping existing."""
+        self._connections.clear()
+        self._connections.extend(
+            map(lambda c: Connection(start=c[0], end=c[1]), connections)
+        )
+
+    @property
+    def latest_power(self) -> SetPowerActiveParam | None:
+        """Get argumetns of the latest charge request."""
+        return self._latest_power
+
+    def get_bounds(self) -> list[SetBoundsParam]:
+        """Return the list of received bounds."""
+        return self._bounds
+
+    def clear_bounds(self) -> None:
+        """Drop all received bounds."""
+        self._bounds.clear()
+
+    # pylint: disable=unused-argument
+    def ListComponents(
+        self,
+        request: ComponentFilter,
+        context: grpc.ServicerContext,
+    ) -> ComponentList:
+        """List components."""
+        return ComponentList(components=self._components)
+
+    def ListAllComponents(
+        self, request: Empty, context: grpc.ServicerContext
+    ) -> ComponentList:
+        """Return a list of all components."""
+        return ComponentList(components=self._components)
+
+    def ListConnections(
+        self, request: ConnectionFilter, context: grpc.ServicerContext
+    ) -> ConnectionList:
+        """Return a list of all connections."""
+        connections: Iterable[Connection] = self._connections
+        if request.starts is not None and len(request.starts) > 0:
+            connections = filter(lambda c: c.start in request.starts, connections)
+        if request.ends is not None and len(request.ends) > 0:
+            connections = filter(lambda c: c.end in request.ends, connections)
+        return ConnectionList(connections=connections)
+
+    def StreamComponentData(
+        self, request: ComponentIdParam, context: grpc.ServicerContext
+    ) -> Iterator[ComponentData]:
+        """Return an iterator for mock ComponentData."""
+        # pylint: disable=stop-iteration-return
+        component = next(filter(lambda c: c.id == request.id, self._components))
+
+        def next_msg() -> ComponentData:
+            ts = Timestamp()
+            ts.GetCurrentTime()
+            if component.category == COMPONENT_CATEGORY_BATTERY:
+                return ComponentData(
+                    id=request.id,
+                    ts=ts,
+                    battery=Battery(
+                        data=BatteryData(
+                            soc=MetricAggregation(avg=float(request.id % 100)),
+                        )
+                    ),
+                )
+            if component.category == COMPONENT_CATEGORY_METER:
+                return ComponentData(
+                    id=request.id,
+                    ts=ts,
+                    meter=Meter(
+                        data=MeterData(
+                            ac=AC(
+                                power_active=Metric(value=100.0),
+                            ),
+                        )
+                    ),
+                )
+            if component.category == COMPONENT_CATEGORY_INVERTER:
+                return ComponentData(id=request.id, inverter=Inverter())
+            if component.category == COMPONENT_CATEGORY_EV_CHARGER:
+                return ComponentData(id=request.id, ev_charger=EvCharger())
+            return ComponentData()
+
+        num_messages = 3
+        for _ in range(num_messages):
+            msg = next_msg()
+            yield msg
+
+    def SetPowerActive(
+        self, request: SetPowerActiveParam, context: grpc.ServicerContext
+    ) -> Empty:
+        """Microgrid service SetPowerActive method stub."""
+        self._latest_power = request
+        return Empty()
+
+    def SetPowerReactive(
+        self, request: SetPowerReactiveParam, context: grpc.ServicerContext
+    ) -> Empty:
+        """Microgrid service SetPowerReactive method stub."""
+        return Empty()
+
+    def GetMicrogridMetadata(
+        self, request: Empty, context: grpc.ServicerContext
+    ) -> MicrogridMetadata:
+        """Microgrid service GetMicrogridMetadata method stub."""
+        return MicrogridMetadata()
+
+    def CanStreamData(
+        self, request: ComponentIdParam, context: grpc.ServicerContext
+    ) -> BoolValue:
+        """Microgrid service CanStreamData method stub."""
+        return BoolValue(value=True)
+
+    def AddExclusionBounds(
+        self, request: SetBoundsParam, context: grpc.ServicerContext
+    ) -> Timestamp:
+        """Microgrid service AddExclusionBounds method stub."""
+        return Timestamp()
+
+    def AddInclusionBounds(
+        self, request: SetBoundsParam, context: grpc.ServicerContext
+    ) -> Timestamp:
+        """Microgrid service AddExclusionBounds method stub."""
+        self._bounds.append(request)
+        return Timestamp()
+
+    def HotStandby(
+        self, request: ComponentIdParam, context: grpc.ServicerContext
+    ) -> Empty:
+        """Microgrid service HotStandby method stub."""
+        return Empty()
+
+    def ColdStandby(
+        self, request: ComponentIdParam, context: grpc.ServicerContext
+    ) -> Empty:
+        """Microgrid service ColdStandby method stub."""
+        return Empty()
+
+    def ErrorAck(
+        self, request: ComponentIdParam, context: grpc.ServicerContext
+    ) -> Empty:
+        """Microgrid service ErrorAck method stub."""
+        return Empty()
+
+    def Start(self, request: ComponentIdParam, context: grpc.ServicerContext) -> Empty:
+        """Microgrid service Start method stub."""
+        return Empty()
+
+    def Stop(self, request: ComponentIdParam, context: grpc.ServicerContext) -> Empty:
+        """Microgrid service Stop method stub."""
+        return Empty()
+
+
+class MockGrpcServer:
+    """Helper class to instantiate a gRPC server for a microgrid servicer."""
+
+    def __init__(
+        self, servicer: MicrogridServicer, host: str = "[::]", port: int = 61060
+    ) -> None:
+        """Create a MockGrpcServicer instance."""
+        self._server = grpc.aio.server(futures.ThreadPoolExecutor(max_workers=20))
+        add_MicrogridServicer_to_server(servicer, self._server)
+        self._server.add_insecure_port(f"{host}:{port}")
+
+    async def start(self) -> None:
+        """Start the server."""
+        await self._server.start()
+
+    async def _stop(self, grace: float | None) -> None:
+        """Stop the server."""
+        await self._server.stop(grace)
+
+    async def _wait_for_termination(self, timeout: float | None = None) -> None:
+        """Wait for termination."""
+        await self._server.wait_for_termination(timeout)
+
+    async def graceful_shutdown(
+        self, stop_timeout: float = 0.1, terminate_timeout: float = 0.2
+    ) -> bool:
+        """Shutdown server gracefully.
+
+        Args:
+            stop_timeout: Argument for self.stop method
+            terminate_timeout: Argument for self.wait_for_termination method.
+
+        Returns:
+            True if server was stopped in given timeout. False otherwise.
+        """
+        await self._stop(stop_timeout)
+        try:
+            await asyncio.wait_for(
+                self._wait_for_termination(None), timeout=terminate_timeout
+            )
+        except TimeoutError:
+            return False
+        return True

--- a/tests/mock_api.py
+++ b/tests/mock_api.py
@@ -57,8 +57,6 @@ from google.protobuf.empty_pb2 import Empty
 from google.protobuf.timestamp_pb2 import Timestamp
 from google.protobuf.wrappers_pb2 import BoolValue
 
-from frequenz.sdk.timeseries import Current
-
 
 class MockMicrogridServicer(  # pylint: disable=too-many-public-methods
     MicrogridServicer
@@ -91,7 +89,7 @@ class MockMicrogridServicer(  # pylint: disable=too-many-public-methods
         self,
         component_id: int,
         component_category: ComponentCategory.V,
-        max_current: Current | None = None,
+        max_current: float | None = None,
         inverter_type: InverterType.V = InverterType.INVERTER_TYPE_UNSPECIFIED,
     ) -> None:
         """Add a component to the mock service."""
@@ -111,7 +109,7 @@ class MockMicrogridServicer(  # pylint: disable=too-many-public-methods
                 Component(
                     id=component_id,
                     category=component_category,
-                    grid=GridMetadata(rated_fuse_current=int(max_current.as_amperes())),
+                    grid=GridMetadata(rated_fuse_current=int(max_current)),
                 )
             )
         else:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,546 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for the microgrid client thin wrapper."""
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator
+
+import grpc
+import pytest
+from frequenz.api.common import components_pb2 as components_pb
+from frequenz.api.common import metrics_pb2 as metrics_pb
+from frequenz.api.microgrid import microgrid_pb2 as microgrid_pb
+from google.protobuf.empty_pb2 import Empty  # pylint: disable=no-name-in-module
+
+from frequenz.sdk.microgrid import client
+from frequenz.sdk.microgrid.client import Connection, LinearBackoff
+from frequenz.sdk.microgrid.component import (
+    BatteryData,
+    Component,
+    ComponentCategory,
+    EVChargerData,
+    GridMetadata,
+    InverterData,
+    InverterType,
+    MeterData,
+)
+from frequenz.sdk.timeseries import Current, Fuse
+
+from . import mock_api
+
+# pylint: disable=missing-function-docstring,use-implicit-booleaness-not-comparison
+# pylint: disable=missing-class-docstring,no-member
+
+
+# This incrementing port is a hack to avoid the inherent flakiness of the approach of
+# using a real GRPC (mock) server. The server seems to stay alive for a short time after
+# the test is finished, which causes the next test to fail because the port is already
+# in use.
+# This is a workaround until we have a better solution.
+# See https://github.com/frequenz-floss/frequenz-sdk-python/issues/662
+_CURRENT_PORT: int = 57897
+
+
+@contextlib.asynccontextmanager
+async def _gprc_server(
+    servicer: mock_api.MockMicrogridServicer | None = None,
+) -> AsyncIterator[tuple[mock_api.MockMicrogridServicer, client.MicrogridApiClient]]:
+    global _CURRENT_PORT  # pylint: disable=global-statement
+    port = _CURRENT_PORT
+    _CURRENT_PORT += 1
+    if servicer is None:
+        servicer = mock_api.MockMicrogridServicer()
+    server = mock_api.MockGrpcServer(servicer, port=port)
+    microgrid = client.MicrogridGrpcClient(
+        grpc.aio.insecure_channel(f"[::]:{port}"),
+        f"[::]:{port}",
+        retry_spec=LinearBackoff(interval=0.0, jitter=0.05),
+    )
+    await server.start()
+    try:
+        yield servicer, microgrid
+    finally:
+        assert await server.graceful_shutdown()
+
+
+class TestMicrogridGrpcClient:
+    """Tests for the microgrid client thin wrapper."""
+
+    async def test_components(self) -> None:
+        """Test the components() method."""
+        async with _gprc_server() as (servicer, microgrid):
+            assert set(await microgrid.components()) == set()
+
+            servicer.add_component(
+                0, components_pb.ComponentCategory.COMPONENT_CATEGORY_METER
+            )
+            assert set(await microgrid.components()) == {
+                Component(0, ComponentCategory.METER)
+            }
+
+            servicer.add_component(
+                0, components_pb.ComponentCategory.COMPONENT_CATEGORY_BATTERY
+            )
+            assert set(await microgrid.components()) == {
+                Component(0, ComponentCategory.METER),
+                Component(0, ComponentCategory.BATTERY),
+            }
+
+            servicer.add_component(
+                0, components_pb.ComponentCategory.COMPONENT_CATEGORY_METER
+            )
+            assert set(await microgrid.components()) == {
+                Component(0, ComponentCategory.METER),
+                Component(0, ComponentCategory.BATTERY),
+                Component(0, ComponentCategory.METER),
+            }
+
+            # sensors are not counted as components by the API client
+            servicer.add_component(
+                1, components_pb.ComponentCategory.COMPONENT_CATEGORY_SENSOR
+            )
+            assert set(await microgrid.components()) == {
+                Component(0, ComponentCategory.METER),
+                Component(0, ComponentCategory.BATTERY),
+                Component(0, ComponentCategory.METER),
+            }
+
+            servicer.set_components(
+                [
+                    (9, components_pb.ComponentCategory.COMPONENT_CATEGORY_METER),
+                    (99, components_pb.ComponentCategory.COMPONENT_CATEGORY_INVERTER),
+                    (666, components_pb.ComponentCategory.COMPONENT_CATEGORY_SENSOR),
+                    (999, components_pb.ComponentCategory.COMPONENT_CATEGORY_BATTERY),
+                ]
+            )
+            assert set(await microgrid.components()) == {
+                Component(9, ComponentCategory.METER),
+                Component(99, ComponentCategory.INVERTER, InverterType.NONE),
+                Component(999, ComponentCategory.BATTERY),
+            }
+
+            servicer.set_components(
+                [
+                    (99, components_pb.ComponentCategory.COMPONENT_CATEGORY_SENSOR),
+                    (
+                        100,
+                        components_pb.ComponentCategory.COMPONENT_CATEGORY_UNSPECIFIED,
+                    ),
+                    (104, components_pb.ComponentCategory.COMPONENT_CATEGORY_METER),
+                    (105, components_pb.ComponentCategory.COMPONENT_CATEGORY_INVERTER),
+                    (106, components_pb.ComponentCategory.COMPONENT_CATEGORY_BATTERY),
+                    (
+                        107,
+                        components_pb.ComponentCategory.COMPONENT_CATEGORY_EV_CHARGER,
+                    ),
+                    (999, components_pb.ComponentCategory.COMPONENT_CATEGORY_SENSOR),
+                ]
+            )
+
+            servicer.add_component(
+                101,
+                components_pb.ComponentCategory.COMPONENT_CATEGORY_GRID,
+                Current.from_amperes(123.0),
+            )
+
+            grid_max_current = Current.from_amperes(123.0)
+            grid_fuse = Fuse(grid_max_current)
+
+            assert set(await microgrid.components()) == {
+                Component(100, ComponentCategory.NONE),
+                Component(
+                    101,
+                    ComponentCategory.GRID,
+                    None,
+                    GridMetadata(fuse=grid_fuse),
+                ),
+                Component(104, ComponentCategory.METER),
+                Component(105, ComponentCategory.INVERTER, InverterType.NONE),
+                Component(106, ComponentCategory.BATTERY),
+                Component(107, ComponentCategory.EV_CHARGER),
+            }
+
+            servicer.set_components(
+                [
+                    (9, components_pb.ComponentCategory.COMPONENT_CATEGORY_METER),
+                    (666, components_pb.ComponentCategory.COMPONENT_CATEGORY_SENSOR),
+                    (999, components_pb.ComponentCategory.COMPONENT_CATEGORY_BATTERY),
+                ]
+            )
+            servicer.add_component(
+                99,
+                components_pb.ComponentCategory.COMPONENT_CATEGORY_INVERTER,
+                None,
+                components_pb.InverterType.INVERTER_TYPE_BATTERY,
+            )
+
+            assert set(await microgrid.components()) == {
+                Component(9, ComponentCategory.METER),
+                Component(99, ComponentCategory.INVERTER, InverterType.BATTERY),
+                Component(999, ComponentCategory.BATTERY),
+            }
+
+    async def test_connections(self) -> None:
+        """Test the connections() method."""
+        async with _gprc_server() as (servicer, microgrid):
+            assert set(await microgrid.connections()) == set()
+
+            servicer.add_connection(0, 0)
+            assert set(await microgrid.connections()) == {Connection(0, 0)}
+
+            servicer.add_connection(7, 9)
+            servicer.add_component(
+                7,
+                component_category=components_pb.ComponentCategory.COMPONENT_CATEGORY_BATTERY,
+            )
+            servicer.add_component(
+                9,
+                component_category=components_pb.ComponentCategory.COMPONENT_CATEGORY_INVERTER,
+            )
+            assert set(await microgrid.connections()) == {
+                Connection(0, 0),
+                Connection(7, 9),
+            }
+
+            servicer.add_connection(0, 0)
+            assert set(await microgrid.connections()) == {
+                Connection(0, 0),
+                Connection(7, 9),
+                Connection(0, 0),
+            }
+
+            servicer.set_connections([(999, 9), (99, 19), (909, 101), (99, 91)])
+            for component_id in [999, 99, 19, 909, 101, 91]:
+                servicer.add_component(
+                    component_id,
+                    components_pb.ComponentCategory.COMPONENT_CATEGORY_BATTERY,
+                )
+
+            assert set(await microgrid.connections()) == {
+                Connection(999, 9),
+                Connection(99, 19),
+                Connection(909, 101),
+                Connection(99, 91),
+            }
+
+            for component_id in [1, 2, 3, 4, 5, 6, 7, 8]:
+                servicer.add_component(
+                    component_id,
+                    components_pb.ComponentCategory.COMPONENT_CATEGORY_BATTERY,
+                )
+
+            servicer.set_connections(
+                [
+                    (1, 2),
+                    (2, 3),
+                    (2, 4),
+                    (2, 5),
+                    (4, 3),
+                    (4, 5),
+                    (4, 6),
+                    (5, 4),
+                    (5, 7),
+                    (5, 8),
+                ]
+            )
+            assert set(await microgrid.connections()) == {
+                Connection(1, 2),
+                Connection(2, 3),
+                Connection(2, 4),
+                Connection(2, 5),
+                Connection(4, 3),
+                Connection(4, 5),
+                Connection(4, 6),
+                Connection(5, 4),
+                Connection(5, 7),
+                Connection(5, 8),
+            }
+
+            # passing empty sets is the same as passing `None`,
+            # filter is ignored
+            assert set(await microgrid.connections(starts=set(), ends=set())) == {
+                Connection(1, 2),
+                Connection(2, 3),
+                Connection(2, 4),
+                Connection(2, 5),
+                Connection(4, 3),
+                Connection(4, 5),
+                Connection(4, 6),
+                Connection(5, 4),
+                Connection(5, 7),
+                Connection(5, 8),
+            }
+
+            # include filter for connection start
+            assert set(await microgrid.connections(starts={1})) == {Connection(1, 2)}
+
+            assert set(await microgrid.connections(starts={2})) == {
+                Connection(2, 3),
+                Connection(2, 4),
+                Connection(2, 5),
+            }
+            assert set(await microgrid.connections(starts={3})) == set()
+
+            assert set(await microgrid.connections(starts={4, 5})) == {
+                Connection(4, 3),
+                Connection(4, 5),
+                Connection(4, 6),
+                Connection(5, 4),
+                Connection(5, 7),
+                Connection(5, 8),
+            }
+
+            # include filter for connection end
+            assert set(await microgrid.connections(ends={1})) == set()
+
+            assert set(await microgrid.connections(ends={3})) == {
+                Connection(2, 3),
+                Connection(4, 3),
+            }
+
+            assert set(await microgrid.connections(ends={2, 4, 5})) == {
+                Connection(1, 2),
+                Connection(2, 4),
+                Connection(2, 5),
+                Connection(4, 5),
+                Connection(5, 4),
+            }
+
+            # different filters combine with AND logic
+            assert set(
+                await microgrid.connections(starts={1, 2, 4}, ends={4, 5, 6})
+            ) == {
+                Connection(2, 4),
+                Connection(2, 5),
+                Connection(4, 5),
+                Connection(4, 6),
+            }
+
+            assert set(await microgrid.connections(starts={3, 5}, ends={7, 8})) == {
+                Connection(5, 7),
+                Connection(5, 8),
+            }
+
+            assert set(await microgrid.connections(starts={1, 5}, ends={2, 7})) == {
+                Connection(1, 2),
+                Connection(5, 7),
+            }
+
+    async def test_bad_connections(self) -> None:
+        """Validate that the client does not apply connection filters itself."""
+
+        class BadServicer(mock_api.MockMicrogridServicer):
+            # pylint: disable=unused-argument,invalid-name
+            def ListConnections(
+                self,
+                request: microgrid_pb.ConnectionFilter,
+                context: grpc.ServicerContext,
+            ) -> microgrid_pb.ConnectionList:
+                """Ignores supplied `ConnectionFilter`."""
+                return microgrid_pb.ConnectionList(connections=self._connections)
+
+            def ListAllComponents(
+                self, request: Empty, context: grpc.ServicerContext
+            ) -> microgrid_pb.ComponentList:
+                return microgrid_pb.ComponentList(components=self._components)
+
+        async with _gprc_server(BadServicer()) as (servicer, microgrid):
+            assert list(await microgrid.connections()) == []
+            for component_id in [1, 2, 3, 4, 5, 6, 7, 8, 9]:
+                servicer.add_component(
+                    component_id,
+                    components_pb.ComponentCategory.COMPONENT_CATEGORY_BATTERY,
+                )
+            servicer.set_connections(
+                [
+                    (1, 2),
+                    (1, 9),
+                    (2, 3),
+                    (3, 4),
+                    (4, 5),
+                    (5, 6),
+                    (6, 7),
+                    (7, 6),
+                    (7, 9),
+                ]
+            )
+
+            unfiltered = {
+                Connection(1, 2),
+                Connection(1, 9),
+                Connection(2, 3),
+                Connection(3, 4),
+                Connection(4, 5),
+                Connection(5, 6),
+                Connection(6, 7),
+                Connection(7, 6),
+                Connection(7, 9),
+            }
+
+            # because the application of filters is left to the server side,
+            # it doesn't matter what filters we set in the client if the
+            # server doesn't do its part
+            assert set(await microgrid.connections()) == unfiltered
+            assert set(await microgrid.connections(starts={1})) == unfiltered
+            assert set(await microgrid.connections(ends={9})) == unfiltered
+            assert (
+                set(await microgrid.connections(starts={1, 7}, ends={3, 9}))
+                == unfiltered
+            )
+
+    async def test_meter_data(self) -> None:
+        """Test the meter_data() method."""
+        async with _gprc_server() as (servicer, microgrid):
+            servicer.add_component(
+                83, components_pb.ComponentCategory.COMPONENT_CATEGORY_METER
+            )
+            servicer.add_component(
+                38, components_pb.ComponentCategory.COMPONENT_CATEGORY_BATTERY
+            )
+
+            with pytest.raises(ValueError):
+                # should raise a ValueError for missing component_id
+                await microgrid.meter_data(20)
+
+            with pytest.raises(ValueError):
+                # should raise a ValueError for wrong component category
+                await microgrid.meter_data(38)
+            receiver = await microgrid.meter_data(83)
+            await asyncio.sleep(0.2)
+
+        latest = await anext(receiver)
+        assert isinstance(latest, MeterData)
+        assert latest.component_id == 83
+
+    async def test_battery_data(self) -> None:
+        """Test the battery_data() method."""
+        async with _gprc_server() as (servicer, microgrid):
+            servicer.add_component(
+                83, components_pb.ComponentCategory.COMPONENT_CATEGORY_BATTERY
+            )
+            servicer.add_component(
+                38, components_pb.ComponentCategory.COMPONENT_CATEGORY_INVERTER
+            )
+
+            with pytest.raises(ValueError):
+                # should raise a ValueError for missing component_id
+                await microgrid.meter_data(20)
+
+            with pytest.raises(ValueError):
+                # should raise a ValueError for wrong component category
+                await microgrid.meter_data(38)
+            receiver = await microgrid.battery_data(83)
+            await asyncio.sleep(0.2)
+
+        latest = await anext(receiver)
+        assert isinstance(latest, BatteryData)
+        assert latest.component_id == 83
+
+    async def test_inverter_data(self) -> None:
+        """Test the inverter_data() method."""
+        async with _gprc_server() as (servicer, microgrid):
+            servicer.add_component(
+                83, components_pb.ComponentCategory.COMPONENT_CATEGORY_INVERTER
+            )
+            servicer.add_component(
+                38, components_pb.ComponentCategory.COMPONENT_CATEGORY_BATTERY
+            )
+
+            with pytest.raises(ValueError):
+                # should raise a ValueError for missing component_id
+                await microgrid.meter_data(20)
+
+            with pytest.raises(ValueError):
+                # should raise a ValueError for wrong component category
+                await microgrid.meter_data(38)
+            receiver = await microgrid.inverter_data(83)
+            await asyncio.sleep(0.2)
+
+        latest = await anext(receiver)
+        assert isinstance(latest, InverterData)
+        assert latest.component_id == 83
+
+    async def test_ev_charger_data(self) -> None:
+        """Test the ev_charger_data() method."""
+        async with _gprc_server() as (servicer, microgrid):
+            servicer.add_component(
+                83, components_pb.ComponentCategory.COMPONENT_CATEGORY_EV_CHARGER
+            )
+            servicer.add_component(
+                38, components_pb.ComponentCategory.COMPONENT_CATEGORY_BATTERY
+            )
+
+            with pytest.raises(ValueError):
+                # should raise a ValueError for missing component_id
+                await microgrid.meter_data(20)
+
+            with pytest.raises(ValueError):
+                # should raise a ValueError for wrong component category
+                await microgrid.meter_data(38)
+            receiver = await microgrid.ev_charger_data(83)
+            await asyncio.sleep(0.2)
+
+        latest = await anext(receiver)
+        assert isinstance(latest, EVChargerData)
+        assert latest.component_id == 83
+
+    async def test_charge(self) -> None:
+        """Check if charge is able to charge component."""
+        async with _gprc_server() as (servicer, microgrid):
+            servicer.add_component(
+                83, components_pb.ComponentCategory.COMPONENT_CATEGORY_METER
+            )
+
+            await microgrid.set_power(component_id=83, power_w=12)
+
+            assert servicer.latest_power is not None
+            assert servicer.latest_power.component_id == 83
+            assert servicer.latest_power.power == 12
+
+    async def test_discharge(self) -> None:
+        """Check if discharge is able to discharge component."""
+        async with _gprc_server() as (servicer, microgrid):
+            servicer.add_component(
+                73, components_pb.ComponentCategory.COMPONENT_CATEGORY_METER
+            )
+
+            await microgrid.set_power(component_id=73, power_w=-15)
+
+            assert servicer.latest_power is not None
+            assert servicer.latest_power.component_id == 73
+            assert servicer.latest_power.power == -15
+
+    async def test_set_bounds(self) -> None:
+        """Check if set_bounds is able to set bounds for component."""
+        async with _gprc_server() as (servicer, microgrid):
+            servicer.add_component(
+                38, components_pb.ComponentCategory.COMPONENT_CATEGORY_INVERTER
+            )
+
+            num_calls = 4
+
+            target_metric = microgrid_pb.SetBoundsParam.TargetMetric
+            expected_bounds = [
+                microgrid_pb.SetBoundsParam(
+                    component_id=comp_id,
+                    target_metric=target_metric.TARGET_METRIC_POWER_ACTIVE,
+                    bounds=metrics_pb.Bounds(lower=-10, upper=2),
+                )
+                for comp_id in range(num_calls)
+            ]
+            for cid in range(num_calls):
+                await microgrid.set_bounds(cid, -10.0, 2.0)
+                await asyncio.sleep(0.1)
+
+        assert len(expected_bounds) == len(servicer.get_bounds())
+
+        def sort_key(
+            bound: microgrid_pb.SetBoundsParam,
+        ) -> microgrid_pb.SetBoundsParam.TargetMetric.ValueType:
+            return bound.target_metric
+
+        assert sorted(servicer.get_bounds(), key=sort_key) == sorted(
+            expected_bounds, key=sort_key
+        )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,13 +12,13 @@ import pytest
 from frequenz.api.common import components_pb2 as components_pb
 from frequenz.api.common import metrics_pb2 as metrics_pb
 from frequenz.api.microgrid import microgrid_pb2 as microgrid_pb
-from frequenz.sdk.timeseries import Current, Fuse
 from google.protobuf.empty_pb2 import Empty  # pylint: disable=no-name-in-module
 
 from frequenz.client.microgrid import _client as client
 from frequenz.client.microgrid._component import (
     Component,
     ComponentCategory,
+    Fuse,
     GridMetadata,
     InverterType,
 )
@@ -145,10 +145,10 @@ class TestMicrogridGrpcClient:
             servicer.add_component(
                 101,
                 components_pb.ComponentCategory.COMPONENT_CATEGORY_GRID,
-                Current.from_amperes(123.0),
+                123.0,
             )
 
-            grid_max_current = Current.from_amperes(123.0)
+            grid_max_current = 123.0
             grid_fuse = Fuse(grid_max_current)
 
             assert set(await microgrid.components()) == {

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,21 +12,24 @@ import pytest
 from frequenz.api.common import components_pb2 as components_pb
 from frequenz.api.common import metrics_pb2 as metrics_pb
 from frequenz.api.microgrid import microgrid_pb2 as microgrid_pb
+from frequenz.sdk.timeseries import Current, Fuse
 from google.protobuf.empty_pb2 import Empty  # pylint: disable=no-name-in-module
 
-from frequenz.sdk.microgrid import client
-from frequenz.sdk.microgrid.client import Connection, LinearBackoff
-from frequenz.sdk.microgrid.component import (
-    BatteryData,
+from frequenz.client.microgrid import _client as client
+from frequenz.client.microgrid._component import (
     Component,
     ComponentCategory,
-    EVChargerData,
     GridMetadata,
-    InverterData,
     InverterType,
+)
+from frequenz.client.microgrid._component_data import (
+    BatteryData,
+    EVChargerData,
+    InverterData,
     MeterData,
 )
-from frequenz.sdk.timeseries import Current, Fuse
+from frequenz.client.microgrid._connection import Connection
+from frequenz.client.microgrid._retry import LinearBackoff
 
 from . import mock_api
 


### PR DESCRIPTION
The microgrid API client code is imported **as-is** from the SDK v1.0.0-rc5, except for some fixes to make `nox`/the CI pass:

- **Fix imports**
- **Add the missing `Fuse` type**
- **Workaround a weird `mypy` error about type mismatch in grpcio**
- **Fix wrong comparison**
- **Ignore pylint check**

Any other cleanups and improvements will be done in future PRs.
