### PR TITLE
Expose missing symbols

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,16 +2,12 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
+This release add some symbols that were missing from the public API:
 
-## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
-## Bug Fixes
-
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
++ `ComponentCategory`
++ `ComponentMetadata`
++ `ComponentMetricId`
++ `ComponentType`
++ `Fuse`
++ `GridMetadata`
++ `InverterType`

--- a/src/frequenz/client/microgrid/__init__.py
+++ b/src/frequenz/client/microgrid/__init__.py
@@ -8,7 +8,16 @@ This package provides a low-level interface for interacting with the microgrid A
 
 
 from ._client import ApiClient
-from ._component import Component
+from ._component import (
+    Component,
+    ComponentCategory,
+    ComponentMetadata,
+    ComponentMetricId,
+    ComponentType,
+    Fuse,
+    GridMetadata,
+    InverterType,
+)
 from ._component_data import (
     BatteryData,
     ComponentData,
@@ -24,12 +33,19 @@ __all__ = [
     "ApiClient",
     "BatteryData",
     "Component",
+    "ComponentCategory",
     "ComponentData",
+    "ComponentMetadata",
+    "ComponentMetricId",
+    "ComponentType",
     "Connection",
     "EVChargerCableState",
     "EVChargerComponentState",
     "EVChargerData",
+    "Fuse",
+    "GridMetadata",
     "InverterData",
+    "InverterType",
     "Location",
     "Metadata",
     "MeterData",

--- a/src/frequenz/client/microgrid/_constants.py
+++ b/src/frequenz/client/microgrid/_constants.py
@@ -6,7 +6,7 @@
 To be replaced by ConfigManager.
 """
 
-RECEIVER_MAX_SIZE = 50
+RECEIVER_MAX_SIZE: int = 50
 """Default buffer size of the receiver."""
 
 WAIT_FOR_COMPONENT_DATA_SEC: float = 2


### PR DESCRIPTION
Add some symbols that were missing from the public API:

+ `ComponentCategory`
+ `ComponentMetadata`
+ `ComponentMetricId`
+ `ComponentType`
+ `Fuse`
+ `GridMetadata`
+ `InverterType`

Also add missing type hint to `RECEIVER_MAX_SIZE`.
