### PR TITLE
Downgrade protobuf to 4.21.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -180,7 +180,7 @@ jobs:
             --net=host \
             --platform linux/${{ matrix.arch }} \
             localhost/nox-cross-arch:latest \
-            bash -c "pip install -e .[dev-noxfile]; nox --install-only -e ${{ matrix.nox-session }}; pip freeze; nox -e ${{ matrix.nox-session }}"
+            bash -c "pip install -e .[dev-noxfile]; nox --install-only -e ${{ matrix.nox-session }}; pip freeze; nox -R -e ${{ matrix.nox-session }}"
         timeout-minutes: 30
 
       # This ensures that the runner has access to the pip cache.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,16 +2,6 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
+This version downgrades the `protobuf` dependency to 4.21.6.
 
-## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
-## Bug Fixes
-
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+This is the version used in the SDK v1.0.0-rc5, which we imported the code from. If we don't do this we introduce an unnecessary dependency conflict with the SDK.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "frequenz-channels == 1.0.0b2",
   "frequenz-client-base >= 0.2.0, < 0.3.0",
   "grpcio >= 1.54.2, < 2",
-  "protobuf >= 4.25.3, < 5",
+  "protobuf >= 4.21.6, < 5",
   "timezonefinder >= 6.2.0, < 7",
   "typing-extensions >= 4.5.0, < 5",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ requires-python = ">= 3.11, < 4"
 dependencies = [
   "frequenz-api-microgrid >= 0.15.3, < 0.16.0",
   "frequenz-channels == 1.0.0b2",
-  "frequenz-client-base >= 0.2.0, < 0.3.0",
+  "frequenz-client-base >= 0.2.1, < 0.3.0",
   "grpcio >= 1.54.2, < 2",
   "protobuf >= 4.21.6, < 5",
   "timezonefinder >= 6.2.0, < 7",


### PR DESCRIPTION
This version should work, as it is the version used in the SDK v1.0.0-rc5. If we don't do this we introduce an unnecessary dependency conflict with the SDK.
