### PR TITLE
Widen the channels dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 requires-python = ">= 3.11, < 4"
 dependencies = [
   "frequenz-api-microgrid >= 0.15.3, < 0.16.0",
-  "frequenz-channels == 1.0.0-rc1",
+  "frequenz-channels >= 1.0.0-rc1, < 2.0.0",
   "frequenz-client-base >= 0.3.0, < 0.4.0",
   "grpcio >= 1.54.2, < 2",
   "protobuf >= 4.21.6, < 5",


### PR DESCRIPTION
We accept any version equal or greater than 1.0.0-rc1 and less than 2.0.0. This is because the channels is now in release candidate so no more breaking changes are expected.
