### PR TITLE
Fix a few bugs related to `GrpcStreamBroadcaster`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Fix a leakage of `GrpcStreamBroadcaster` instances.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,3 +15,4 @@
 ## Bug Fixes
 
 - Fix a leakage of `GrpcStreamBroadcaster` instances.
+- The user-passed retry strategy was not properly used by the data streaming methods.

--- a/src/frequenz/client/microgrid/_client.py
+++ b/src/frequenz/client/microgrid/_client.py
@@ -273,6 +273,7 @@ class ApiClient:
                     self.api.StreamComponentData(PbComponentIdParam(id=component_id)),
                 ),
                 transform,
+                retry_strategy=self._retry_strategy,
             )
             self._broadcasters[component_id] = broadcaster
         return broadcaster.new_receiver(maxsize=maxsize)

--- a/src/frequenz/client/microgrid/_client.py
+++ b/src/frequenz/client/microgrid/_client.py
@@ -261,9 +261,9 @@ class ApiClient:
             expected_category,
         )
 
-        broadcaster = self._broadcasters.setdefault(
-            component_id,
-            streaming.GrpcStreamBroadcaster(
+        broadcaster = self._broadcasters.get(component_id)
+        if broadcaster is None:
+            broadcaster = streaming.GrpcStreamBroadcaster(
                 f"raw-component-data-{component_id}",
                 # We need to cast here because grpc says StreamComponentData is
                 # a grpc.CallIterator[PbComponentData], not a
@@ -273,8 +273,8 @@ class ApiClient:
                     self.api.StreamComponentData(PbComponentIdParam(id=component_id)),
                 ),
                 transform,
-            ),
-        )
+            )
+            self._broadcasters[component_id] = broadcaster
         return broadcaster.new_receiver(maxsize=maxsize)
 
     async def _expect_category(


### PR DESCRIPTION
When a broadcaster already existed, a new one was created but immediately discarded, as it was never saved. Instead we really want to avoid creating a new broadcaster if one already exists.

Also when introducing the `GrpcStreamBroadcaster` from `client-base` we forgot to forward the selected retry strategy to it.