### PR TITLE
Bump client-base to v0.4.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- The client is now using [`grpclib`](https://pypi.org/project/grpclib/) to connect to the server instead of [`grpcio`](https://pypi.org/project/grpcio/). You might need to adapt the way you connect to the server in your code, using `grpcio.client.Channel` and catching `grpcio.GRPCError` exceptions.
 
 ## New Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ requires-python = ">= 3.11, < 4"
 dependencies = [
   "frequenz-api-microgrid >= 0.15.3, < 0.16.0",
   "frequenz-channels >= 1.0.0-rc1, < 2.0.0",
-  "frequenz-client-base >= 0.3.0, < 0.4.0",
+  "frequenz-client-base[grpclib] >= 0.4.0, < 0.5",
   "grpcio >= 1.54.2, < 2",
   "protobuf >= 4.21.6, < 6",
   "timezonefinder >= 6.2.0, < 7",

--- a/src/frequenz/client/microgrid/_client.py
+++ b/src/frequenz/client/microgrid/_client.py
@@ -5,7 +5,7 @@
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable, Iterable
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
 from typing import Any, TypeVar, cast
 
 import grpc.aio
@@ -266,10 +266,11 @@ class ApiClient:
             broadcaster = streaming.GrpcStreamBroadcaster(
                 f"raw-component-data-{component_id}",
                 # We need to cast here because grpc says StreamComponentData is
-                # a grpc.CallIterator[PbComponentData], not a
-                # grpc.aio.UnaryStreamCall[..., PbComponentData].
+                # a grpc.CallIterator[PbComponentData] which is not an AsyncIterator,
+                # but it is a grpc.aio.UnaryStreamCall[..., PbComponentData], which it
+                # is.
                 lambda: cast(
-                    grpc.aio.UnaryStreamCall[Any, PbComponentData],
+                    AsyncIterator[PbComponentData],
                     self.api.StreamComponentData(PbComponentIdParam(id=component_id)),
                 ),
                 transform,


### PR DESCRIPTION
We need this to be able to use it with `grpclib` instead of `grpcio`.
