### PR TITLE
Properly await for `AddInclusionBounds`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,3 +16,4 @@
 
 - Fix a leakage of `GrpcStreamBroadcaster` instances.
 - The user-passed retry strategy was not properly used by the data streaming methods.
+- The client `set_bounds()` method might have not done anything and if it did, errors were not properly raised.

--- a/src/frequenz/client/microgrid/_client.py
+++ b/src/frequenz/client/microgrid/_client.py
@@ -478,6 +478,7 @@ class ApiClient:
                         target_metric=target_metric,
                         bounds=PbBounds(lower=lower, upper=upper),
                     ),
+                    timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
                 ),
             )
         except grpc.aio.AioRpcError as err:

--- a/src/frequenz/client/microgrid/_client.py
+++ b/src/frequenz/client/microgrid/_client.py
@@ -425,7 +425,7 @@ class ApiClient:
         """
         try:
             await cast(
-                Awaitable[PbSetPowerActiveParam],
+                Awaitable[Empty],
                 self.api.SetPowerActive(
                     PbSetPowerActiveParam(component_id=component_id, power=power_w),
                     timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),

--- a/src/frequenz/client/microgrid/_client.py
+++ b/src/frequenz/client/microgrid/_client.py
@@ -32,6 +32,7 @@ from frequenz.api.microgrid.microgrid_pb2_grpc import MicrogridStub
 from frequenz.channels import Receiver
 from frequenz.client.base import retry, streaming
 from google.protobuf.empty_pb2 import Empty  # pylint: disable=no-name-in-module
+from google.protobuf.timestamp_pb2 import Timestamp  # pylint: disable=no-name-in-module
 
 from ._component import (
     Component,
@@ -469,11 +470,14 @@ class ApiClient:
 
         target_metric = PbSetBoundsParam.TargetMetric.TARGET_METRIC_POWER_ACTIVE
         try:
-            self.api.AddInclusionBounds(
-                PbSetBoundsParam(
-                    component_id=component_id,
-                    target_metric=target_metric,
-                    bounds=PbBounds(lower=lower, upper=upper),
+            await cast(
+                Awaitable[Timestamp],
+                self.api.AddInclusionBounds(
+                    PbSetBoundsParam(
+                        component_id=component_id,
+                        target_metric=target_metric,
+                        bounds=PbBounds(lower=lower, upper=upper),
+                    ),
                 ),
             )
         except grpc.aio.AioRpcError as err:


### PR DESCRIPTION
Without this, the function call will never actually run. I'm not sure if this was working anyways because of some obscure implementation detail in grpcio, but in normal python a not awaited async function should never actually run.

Besides this, for sure errors can't be really caught without the await either.

This was detected while migrating to betterproto, as betterproto has correct type hints.

