### PR TITLE
Raise a new `ClientError` instead of `AioRpcError`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,8 @@
 
 ## Upgrading
 
-- The client is now using [`grpclib`](https://pypi.org/project/grpclib/) to connect to the server instead of [`grpcio`](https://pypi.org/project/grpcio/). You might need to adapt the way you connect to the server in your code, using `grpcio.client.Channel` and catching `grpcio.GRPCError` exceptions.
+- The client is now using [`grpclib`](https://pypi.org/project/grpclib/) to connect to the server instead of [`grpcio`](https://pypi.org/project/grpcio/). You might need to adapt the way you connect to the server in your code, using `grpcio.client.Channel`.
+- The client now doesn't raise `grpc.aio.RpcError` exceptions anymore. Instead, it raises `ClientError` exceptions that have the `grpc.aio.RpcError` as their `__cause__`. You might need to adapt your error handling code to catch `ClientError` exceptions instead of `grpc.aio.RpcError` exceptions.
 
 ## New Features
 

--- a/src/frequenz/client/microgrid/__init__.py
+++ b/src/frequenz/client/microgrid/__init__.py
@@ -27,11 +27,13 @@ from ._component_data import (
 )
 from ._component_states import EVChargerCableState, EVChargerComponentState
 from ._connection import Connection
+from ._exception import ClientError
 from ._metadata import Location, Metadata
 
 __all__ = [
     "ApiClient",
     "BatteryData",
+    "ClientError",
     "Component",
     "ComponentCategory",
     "ComponentData",

--- a/src/frequenz/client/microgrid/_exception.py
+++ b/src/frequenz/client/microgrid/_exception.py
@@ -1,0 +1,8 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Exceptions raised by the microgrid API client."""
+
+
+class ClientError(Exception):
+    """There was an error in the microgrid API client."""


### PR DESCRIPTION
We want to avoid exposing the underlying details of the client, so in the future we can change the libraries used to connect to the service, or even the protocol.

This also removes the re-building of the exceptions, which was pretty unnecessary and needed some `type: ignore`s due to typing issues in `grpcio`.

We should probably create a separate error for timeouts in the future.
