### PR TITLE
Make the client accept a server URL to connect to

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,9 +6,10 @@
 
 ## Upgrading
 
-- The client is now using [`grpclib`](https://pypi.org/project/grpclib/) to connect to the server instead of [`grpcio`](https://pypi.org/project/grpcio/). You might need to adapt the way you connect to the server in your code, using `grpcio.client.Channel`.
+- The client now uses a string URL to connect to the server, the `grpc_channel` and `target` arguments are now replaced by `server_url`. The current accepted format is `grpc://hostname[:<port:int=9090>][?ssl=<ssl:bool=false>]`, meaning that the `port` and `ssl` are optional and default to 9090 and `false` respectively. You will have to adapt the way you connect to the server in your code.
+- The client is now using [`grpclib`](https://pypi.org/project/grpclib/) to connect to the server instead of [`grpcio`](https://pypi.org/project/grpcio/). You might need to adapt your code if you are using `grpcio` directly.
 - The client now doesn't raise `grpc.aio.RpcError` exceptions anymore. Instead, it raises `ClientError` exceptions that have the `grpclib.GRPCError` as their `__cause__`. You might need to adapt your error handling code to catch `ClientError` exceptions instead of `grpc.aio.RpcError` exceptions.
-- The client now uses protobuf/grpc bindings generated [betterproto](https://github.com/danielgtaylor/python-betterproto) instead of [grpcio](https://pypi.org/project/grpcio/). If you were using the bindings directly, you might need to do some minor adjustments to your code.
+- The client now uses protobuf/grpc bindings generated [betterproto](https://github.com/danielgtaylor/python-betterproto) ([frequenz-microgrid-betterproto](https://github.com/frequenz-floss/frequenz-microgrid-betterproto-python)) instead of [grpcio](https://pypi.org/project/grpcio/) ([frequenz-api-microgrid](https://github.com/frequenz-floss/frequenz-api-microgrid)). If you were using the bindings directly, you might need to do some minor adjustments to your code.
 
 ## New Features
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,11 +57,8 @@ from frequenz.client.microgrid._connection import Connection
 
 class _TestClient(ApiClient):
     def __init__(self, *, retry_strategy: retry.Strategy | None = None) -> None:
-        mock_channel = mock.MagicMock(name="channel", spec=grpclib.client.Channel)
         mock_stub = mock.MagicMock(name="stub", spec=microgrid.MicrogridStub)
-        target = "mock_host:1234"
-        super().__init__(mock_channel, target, retry_strategy)
-        self.mock_channel = mock_channel
+        super().__init__("grpc://mock_host:1234", retry_strategy=retry_strategy)
         self.mock_stub = mock_stub
         self.api = mock_stub
 
@@ -215,7 +212,8 @@ async def test_components_grpc_error() -> None:
     )
     with pytest.raises(
         ClientError,
-        match="Failed to list components. Microgrid API: mock_host:1234. Err: .*fake grpc error",
+        match="Failed to list components. Microgrid API: grpc://mock_host:1234. "
+        "Err: .*fake grpc error",
     ):
         await client.components()
 
@@ -354,7 +352,8 @@ async def test_connections_grpc_error() -> None:
     )
     with pytest.raises(
         ClientError,
-        match="Failed to list connections. Microgrid API: mock_host:1234. Err: .*fake grpc error",
+        match="Failed to list connections. Microgrid API: grpc://mock_host:1234. "
+        "Err: .*fake grpc error",
     ):
         await client.connections()
 
@@ -569,7 +568,8 @@ async def test_set_power_grpc_error() -> None:
     )
     with pytest.raises(
         ClientError,
-        match="Failed to set power. Microgrid API: mock_host:1234. Err: .*fake grpc error",
+        match="Failed to set power. Microgrid API: grpc://mock_host:1234. "
+        "Err: .*fake grpc error",
     ):
         await client.set_power(component_id=83, power_w=100.0)
 
@@ -634,7 +634,7 @@ async def test_set_bounds_grpc_error() -> None:
     )
     with pytest.raises(
         ClientError,
-        match="Failed to set inclusion bounds. Microgrid API: mock_host:1234. "
+        match="Failed to set inclusion bounds. Microgrid API: grpc://mock_host:1234. "
         "Err: .*fake grpc error",
     ):
         await client.set_bounds(99, 0.0, 100.0)


### PR DESCRIPTION
This URL is a string with the form `grpc://hostname[:<port:int=9090>][?ssl=<ssl:bool=false>]`, meaning that the `port` and `ssl` are optional and default to 9090 and `false` respectively.

This makes it more convenient to take server URLs from config files and enviroment variables, but it also means gRPC channels are not exposed directly to users anymore, so the internal implementation to connect to the gRPC server can be changed without it being a breaking change (we could potentially even change the protocol completely to use something else rather than gRPC).
