### PR TITLE
Configure dependabot to have separate minor updates for in-devel deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,11 +25,36 @@ updates:
         update-types:
           - "minor"
           - "patch"
+        patterns:
+          - "^(?!frequenz-client-base\\[grpclib\\]).*$"
+          - "^(?!frequenz-microgrid-betterproto).*$"
       optional:
         dependency-type: "development"
         update-types:
           - "minor"
           - "patch"
+        patterns:
+          - "^(?!frequenz-client-base\\[grpclib\\]).*$"
+          - "^(?!frequenz-microgrid-betterproto).*$"
+      in-devel-patch:
+        patterns:
+          - "^frequenz-client-base\\[grpclib\\].*$"
+          - "^frequenz-microgrid-betterproto.*$"
+        dependency-type: "production"
+        update-types:
+          - "patch"
+      client-base-minor:
+        patterns:
+          - "^frequenz-client-base\\[grpclib\\].*$"
+        dependency-type: "production"
+        update-types:
+          - "minor"
+      microgrid-betterproto-minor:
+        patterns:
+          - "^frequenz-microgrid-betterproto.*$"
+        dependency-type: "production"
+        update-types:
+          - "minor"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
The `frequenz-client-base` and `frequenz-microgrid-betterproto` dependencies are in-development and every minor update is potentially (and very likely) a breaking change. Because of this we want dependabot to create separate PRs for minor updates for these dependencies.

For patch updates we still want to group them together, because they not supposed to be breaking changes.
