### PR TITLE
Fix patterns in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,36 +25,24 @@ updates:
         update-types:
           - "minor"
           - "patch"
-        patterns:
-          - "^(?!frequenz-client-base\\[grpclib\\]).*$"
-          - "^(?!frequenz-microgrid-betterproto).*$"
+        exclude-patterns:
+          - "frequenz-client-base*"
+          - "frequenz-microgrid-betterproto*"
       optional:
         dependency-type: "development"
         update-types:
           - "minor"
           - "patch"
-        patterns:
-          - "^(?!frequenz-client-base\\[grpclib\\]).*$"
-          - "^(?!frequenz-microgrid-betterproto).*$"
+        exclude-patterns:
+          - "frequenz-client-base*"
+          - "frequenz-microgrid-betterproto*"
       in-devel-patch:
         patterns:
-          - "^frequenz-client-base\\[grpclib\\].*$"
-          - "^frequenz-microgrid-betterproto.*$"
+          - "frequenz-client-base*"
+          - "frequenz-microgrid-betterproto*"
         dependency-type: "production"
         update-types:
           - "patch"
-      client-base-minor:
-        patterns:
-          - "^frequenz-client-base\\[grpclib\\].*$"
-        dependency-type: "production"
-        update-types:
-          - "minor"
-      microgrid-betterproto-minor:
-        patterns:
-          - "^frequenz-microgrid-betterproto.*$"
-        dependency-type: "production"
-        update-types:
-          - "minor"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
The new dependabot file updated by #61 had many issues that we fix in this commit:

* The patterns should be glob-like patterns instead of regex patterns.
* We should `exclude-patterns` instead of `patterns` (with a negating regex) to exclude some dependencies.
* We don't actually need the `*-minor` groups, as anything that is not grouped will have a separate PR anyway.