### PR TITLE
Disable` pylint`s `no-name-in-module` check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ disable = [
   "unsubscriptable-object",
   # Checked by mypy
   "no-member",
+  "no-name-in-module",
   # Checked by flake8
   "f-string-without-interpolation",
   "line-too-long",

--- a/src/frequenz/client/microgrid/_client.py
+++ b/src/frequenz/client/microgrid/_client.py
@@ -9,8 +9,6 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Set
 from typing import Any, TypeVar, cast
 
 import grpc.aio
-
-# pylint: disable=no-name-in-module
 from frequenz.api.common.components_pb2 import ComponentCategory as PbComponentCategory
 from frequenz.api.common.metrics_pb2 import Bounds as PbBounds
 from frequenz.api.microgrid.microgrid_pb2 import ComponentData as PbComponentData
@@ -27,12 +25,10 @@ from frequenz.api.microgrid.microgrid_pb2 import (
     SetPowerActiveParam as PbSetPowerActiveParam,
 )
 from frequenz.api.microgrid.microgrid_pb2_grpc import MicrogridStub
-
-# pylint: enable=no-name-in-module
 from frequenz.channels import Receiver
 from frequenz.client.base import channel, retry, streaming
-from google.protobuf.empty_pb2 import Empty  # pylint: disable=no-name-in-module
-from google.protobuf.timestamp_pb2 import Timestamp  # pylint: disable=no-name-in-module
+from google.protobuf.empty_pb2 import Empty
+from google.protobuf.timestamp_pb2 import Timestamp
 
 from ._component import (
     Component,

--- a/src/frequenz/client/microgrid/_client.py
+++ b/src/frequenz/client/microgrid/_client.py
@@ -9,22 +9,8 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Set
 from typing import Any, TypeVar, cast
 
 import grpc.aio
-from frequenz.api.common.components_pb2 import ComponentCategory as PbComponentCategory
-from frequenz.api.common.metrics_pb2 import Bounds as PbBounds
-from frequenz.api.microgrid.microgrid_pb2 import ComponentData as PbComponentData
-from frequenz.api.microgrid.microgrid_pb2 import ComponentFilter as PbComponentFilter
-from frequenz.api.microgrid.microgrid_pb2 import ComponentIdParam as PbComponentIdParam
-from frequenz.api.microgrid.microgrid_pb2 import ComponentList as PbComponentList
-from frequenz.api.microgrid.microgrid_pb2 import ConnectionFilter as PbConnectionFilter
-from frequenz.api.microgrid.microgrid_pb2 import ConnectionList as PbConnectionList
-from frequenz.api.microgrid.microgrid_pb2 import (
-    MicrogridMetadata as PbMicrogridMetadata,
-)
-from frequenz.api.microgrid.microgrid_pb2 import SetBoundsParam as PbSetBoundsParam
-from frequenz.api.microgrid.microgrid_pb2 import (
-    SetPowerActiveParam as PbSetPowerActiveParam,
-)
-from frequenz.api.microgrid.microgrid_pb2_grpc import MicrogridStub
+from frequenz.api.common import components_pb2, metrics_pb2
+from frequenz.api.microgrid import microgrid_pb2, microgrid_pb2_grpc
 from frequenz.channels import Receiver
 from frequenz.client.base import channel, retry, streaming
 from google.protobuf.empty_pb2 import Empty
@@ -83,7 +69,7 @@ class ApiClient:
         self._server_url = server_url
         """The location of the microgrid API server as a URL."""
 
-        self.api = MicrogridStub(channel.parse_grpc_uri(server_url))
+        self.api = microgrid_pb2_grpc.MicrogridStub(channel.parse_grpc_uri(server_url))
         """The gRPC stub for the microgrid API."""
 
         self._broadcasters: dict[int, streaming.GrpcStreamBroadcaster[Any, Any]] = {}
@@ -109,9 +95,9 @@ class ApiClient:
             # grpc.aio is missing types and mypy thinks this is not awaitable,
             # but it is
             component_list = await cast(
-                Awaitable[PbComponentList],
+                Awaitable[microgrid_pb2.ComponentList],
                 self.api.ListComponents(
-                    PbComponentFilter(),
+                    microgrid_pb2.ComponentFilter(),
                     timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
                 ),
             )
@@ -123,7 +109,8 @@ class ApiClient:
             ) from grpc_error
 
         components_only = filter(
-            lambda c: c.category is not PbComponentCategory.COMPONENT_CATEGORY_SENSOR,
+            lambda c: c.category
+            is not components_pb2.ComponentCategory.COMPONENT_CATEGORY_SENSOR,
             component_list.components,
         )
         result: Iterable[Component] = map(
@@ -147,10 +134,10 @@ class ApiClient:
         Returns:
             the microgrid metadata.
         """
-        microgrid_metadata: PbMicrogridMetadata | None = None
+        microgrid_metadata: microgrid_pb2.MicrogridMetadata | None = None
         try:
             microgrid_metadata = await cast(
-                Awaitable[PbMicrogridMetadata],
+                Awaitable[microgrid_pb2.MicrogridMetadata],
                 self.api.GetMicrogridMetadata(
                     Empty(),
                     timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
@@ -192,14 +179,14 @@ class ApiClient:
                 most likely a subclass of
                 [GrpcError][frequenz.client.microgrid.GrpcError].
         """
-        connection_filter = PbConnectionFilter(starts=starts, ends=ends)
+        connection_filter = microgrid_pb2.ConnectionFilter(starts=starts, ends=ends)
         try:
             valid_components, all_connections = await asyncio.gather(
                 self.components(),
                 # grpc.aio is missing types and mypy thinks this is not
                 # awaitable, but it is
                 cast(
-                    Awaitable[PbConnectionList],
+                    Awaitable[microgrid_pb2.ConnectionList],
                     self.api.ListConnections(
                         connection_filter,
                         timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
@@ -233,7 +220,7 @@ class ApiClient:
         *,
         component_id: int,
         expected_category: ComponentCategory,
-        transform: Callable[[PbComponentData], _ComponentDataT],
+        transform: Callable[[microgrid_pb2.ComponentData], _ComponentDataT],
         maxsize: int,
     ) -> Receiver[_ComponentDataT]:
         """Return a new broadcaster receiver for a given `component_id`.
@@ -261,12 +248,14 @@ class ApiClient:
             broadcaster = streaming.GrpcStreamBroadcaster(
                 f"raw-component-data-{component_id}",
                 # We need to cast here because grpc says StreamComponentData is
-                # a grpc.CallIterator[PbComponentData] which is not an AsyncIterator,
-                # but it is a grpc.aio.UnaryStreamCall[..., PbComponentData], which it
-                # is.
+                # a grpc.CallIterator[microgrid_pb2.ComponentData] which is not an
+                # AsyncIterator, but it is a grpc.aio.UnaryStreamCall[...,
+                # microgrid_pb2.ComponentData], which it is.
                 lambda: cast(
-                    AsyncIterator[PbComponentData],
-                    self.api.StreamComponentData(PbComponentIdParam(id=component_id)),
+                    AsyncIterator[microgrid_pb2.ComponentData],
+                    self.api.StreamComponentData(
+                        microgrid_pb2.ComponentIdParam(id=component_id)
+                    ),
                 ),
                 transform,
                 retry_strategy=self._retry_strategy,
@@ -423,7 +412,9 @@ class ApiClient:
             await cast(
                 Awaitable[Empty],
                 self.api.SetPowerActive(
-                    PbSetPowerActiveParam(component_id=component_id, power=power_w),
+                    microgrid_pb2.SetPowerActiveParam(
+                        component_id=component_id, power=power_w
+                    ),
                     timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
                 ),
             )
@@ -440,7 +431,7 @@ class ApiClient:
         lower: float,
         upper: float,
     ) -> None:
-        """Send `PbSetBoundsParam`s received from a channel to the Microgrid service.
+        """Send `SetBoundsParam`s received from a channel to the Microgrid service.
 
         Args:
             component_id: ID of the component to set bounds for.
@@ -459,15 +450,17 @@ class ApiClient:
         if lower > 0:
             raise ValueError(f"Lower bound {lower} must be less than or equal to 0.")
 
-        target_metric = PbSetBoundsParam.TargetMetric.TARGET_METRIC_POWER_ACTIVE
+        target_metric = (
+            microgrid_pb2.SetBoundsParam.TargetMetric.TARGET_METRIC_POWER_ACTIVE
+        )
         try:
             await cast(
                 Awaitable[Timestamp],
                 self.api.AddInclusionBounds(
-                    PbSetBoundsParam(
+                    microgrid_pb2.SetBoundsParam(
                         component_id=component_id,
                         target_metric=target_metric,
-                        bounds=PbBounds(lower=lower, upper=upper),
+                        bounds=metrics_pb2.Bounds(lower=lower, upper=upper),
                     ),
                     timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
                 ),

--- a/src/frequenz/client/microgrid/_component.py
+++ b/src/frequenz/client/microgrid/_component.py
@@ -6,10 +6,8 @@
 from dataclasses import dataclass
 from enum import Enum
 
-from frequenz.api.common.components_pb2 import ComponentCategory as PbComponentCategory
-from frequenz.api.microgrid.grid_pb2 import Metadata as PbGridMetadata
-from frequenz.api.microgrid.inverter_pb2 import Metadata as PbInverterMetadata
-from frequenz.api.microgrid.inverter_pb2 import Type as PbInverterType
+from frequenz.api.common import components_pb2
+from frequenz.api.microgrid import grid_pb2, inverter_pb2
 
 
 class ComponentType(Enum):
@@ -19,22 +17,22 @@ class ComponentType(Enum):
 class InverterType(ComponentType):
     """Enum representing inverter types."""
 
-    NONE = PbInverterType.TYPE_UNSPECIFIED
+    NONE = inverter_pb2.Type.TYPE_UNSPECIFIED
     """Unspecified inverter type."""
 
-    BATTERY = PbInverterType.TYPE_BATTERY
+    BATTERY = inverter_pb2.Type.TYPE_BATTERY
     """Battery inverter."""
 
-    SOLAR = PbInverterType.TYPE_SOLAR
+    SOLAR = inverter_pb2.Type.TYPE_SOLAR
     """Solar inverter."""
 
-    HYBRID = PbInverterType.TYPE_HYBRID
+    HYBRID = inverter_pb2.Type.TYPE_HYBRID
     """Hybrid inverter."""
 
 
 def component_type_from_protobuf(
-    component_category: PbComponentCategory.ValueType,
-    component_metadata: PbInverterMetadata,
+    component_category: components_pb2.ComponentCategory.ValueType,
+    component_metadata: inverter_pb2.Metadata,
 ) -> ComponentType | None:
     """Convert a protobuf InverterType message to Component enum.
 
@@ -50,7 +48,10 @@ def component_type_from_protobuf(
     # ComponentType values in the protobuf definition are not unique across categories
     # as of v0.11.0, so we need to check the component category first, before doing any
     # component type checks.
-    if component_category == PbComponentCategory.COMPONENT_CATEGORY_INVERTER:
+    if (
+        component_category
+        == components_pb2.ComponentCategory.COMPONENT_CATEGORY_INVERTER
+    ):
         if not any(int(t.value) == int(component_metadata.type) for t in InverterType):
             return None
 
@@ -62,30 +63,30 @@ def component_type_from_protobuf(
 class ComponentCategory(Enum):
     """Possible types of microgrid component."""
 
-    NONE = PbComponentCategory.COMPONENT_CATEGORY_UNSPECIFIED
+    NONE = components_pb2.ComponentCategory.COMPONENT_CATEGORY_UNSPECIFIED
     """Unspecified component category."""
 
-    GRID = PbComponentCategory.COMPONENT_CATEGORY_GRID
+    GRID = components_pb2.ComponentCategory.COMPONENT_CATEGORY_GRID
     """Grid component."""
 
-    METER = PbComponentCategory.COMPONENT_CATEGORY_METER
+    METER = components_pb2.ComponentCategory.COMPONENT_CATEGORY_METER
     """Meter component."""
 
-    INVERTER = PbComponentCategory.COMPONENT_CATEGORY_INVERTER
+    INVERTER = components_pb2.ComponentCategory.COMPONENT_CATEGORY_INVERTER
     """Inverter component."""
 
-    BATTERY = PbComponentCategory.COMPONENT_CATEGORY_BATTERY
+    BATTERY = components_pb2.ComponentCategory.COMPONENT_CATEGORY_BATTERY
     """Battery component."""
 
-    EV_CHARGER = PbComponentCategory.COMPONENT_CATEGORY_EV_CHARGER
+    EV_CHARGER = components_pb2.ComponentCategory.COMPONENT_CATEGORY_EV_CHARGER
     """EV charger component."""
 
-    CHP = PbComponentCategory.COMPONENT_CATEGORY_CHP
+    CHP = components_pb2.ComponentCategory.COMPONENT_CATEGORY_CHP
     """CHP component."""
 
 
 def component_category_from_protobuf(
-    component_category: PbComponentCategory.ValueType,
+    component_category: components_pb2.ComponentCategory.ValueType,
 ) -> ComponentCategory:
     """Convert a protobuf ComponentCategory message to ComponentCategory enum.
 
@@ -102,7 +103,7 @@ def component_category_from_protobuf(
             a valid component category as it does not form part of the
             microgrid itself)
     """
-    if component_category == PbComponentCategory.COMPONENT_CATEGORY_SENSOR:
+    if component_category == components_pb2.ComponentCategory.COMPONENT_CATEGORY_SENSOR:
         raise ValueError("Cannot create a component from a sensor!")
 
     if not any(t.value == component_category for t in ComponentCategory):
@@ -133,8 +134,8 @@ class GridMetadata(ComponentMetadata):
 
 
 def component_metadata_from_protobuf(
-    component_category: PbComponentCategory.ValueType,
-    component_metadata: PbGridMetadata,
+    component_category: components_pb2.ComponentCategory.ValueType,
+    component_metadata: grid_pb2.Metadata,
 ) -> GridMetadata | None:
     """Convert a protobuf GridMetadata message to GridMetadata class.
 
@@ -147,7 +148,7 @@ def component_metadata_from_protobuf(
     Returns:
         GridMetadata instance corresponding to the protobuf message.
     """
-    if component_category == PbComponentCategory.COMPONENT_CATEGORY_GRID:
+    if component_category == components_pb2.ComponentCategory.COMPONENT_CATEGORY_GRID:
         max_current = component_metadata.rated_fuse_current
         fuse = Fuse(max_current)
         return GridMetadata(fuse)

--- a/src/frequenz/client/microgrid/_component.py
+++ b/src/frequenz/client/microgrid/_component.py
@@ -6,13 +6,10 @@
 from dataclasses import dataclass
 from enum import Enum
 
-# pylint: disable=no-name-in-module
 from frequenz.api.common.components_pb2 import ComponentCategory as PbComponentCategory
 from frequenz.api.microgrid.grid_pb2 import Metadata as PbGridMetadata
 from frequenz.api.microgrid.inverter_pb2 import Metadata as PbInverterMetadata
 from frequenz.api.microgrid.inverter_pb2 import Type as PbInverterType
-
-# pylint: enable=no-name-in-module
 
 
 class ComponentType(Enum):

--- a/src/frequenz/client/microgrid/_component_data.py
+++ b/src/frequenz/client/microgrid/_component_data.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Self
 
-from frequenz.api.microgrid.microgrid_pb2 import ComponentData as PbComponentData
+from frequenz.api.microgrid import microgrid_pb2
 
 from ._component_error import BatteryError, InverterError
 from ._component_states import (
@@ -35,10 +35,10 @@ class ComponentData(ABC):
     # data from a protobuf message. The whole protobuf message is stored as the `raw`
     # attribute. When `ComponentData` is not instantiated from a protobuf message,
     # i.e. using the constructor, `raw` will be set to `None`.
-    raw: PbComponentData | None = field(default=None, init=False)
+    raw: microgrid_pb2.ComponentData | None = field(default=None, init=False)
     """Raw component data as decoded from the wire."""
 
-    def _set_raw(self, raw: PbComponentData) -> None:
+    def _set_raw(self, raw: microgrid_pb2.ComponentData) -> None:
         """Store raw protobuf message.
 
         It is preferred to keep the dataclasses immutable (frozen) and make the `raw`
@@ -52,7 +52,7 @@ class ComponentData(ABC):
 
     @classmethod
     @abstractmethod
-    def from_proto(cls, raw: PbComponentData) -> Self:
+    def from_proto(cls, raw: microgrid_pb2.ComponentData) -> Self:
         """Create ComponentData from a protobuf message.
 
         Args:
@@ -119,7 +119,7 @@ class MeterData(ComponentData):
     """The AC power frequency in Hertz (Hz)."""
 
     @classmethod
-    def from_proto(cls, raw: PbComponentData) -> Self:
+    def from_proto(cls, raw: microgrid_pb2.ComponentData) -> Self:
         """Create MeterData from a protobuf message.
 
         Args:
@@ -236,7 +236,7 @@ class BatteryData(ComponentData):  # pylint: disable=too-many-instance-attribute
     """List of errors in protobuf struct."""
 
     @classmethod
-    def from_proto(cls, raw: PbComponentData) -> Self:
+    def from_proto(cls, raw: microgrid_pb2.ComponentData) -> Self:
         """Create BatteryData from a protobuf message.
 
         Args:
@@ -374,7 +374,7 @@ class InverterData(ComponentData):  # pylint: disable=too-many-instance-attribut
     """List of errors from the component."""
 
     @classmethod
-    def from_proto(cls, raw: PbComponentData) -> Self:
+    def from_proto(cls, raw: microgrid_pb2.ComponentData) -> Self:
         """Create InverterData from a protobuf message.
 
         Args:
@@ -530,7 +530,7 @@ class EVChargerData(ComponentData):  # pylint: disable=too-many-instance-attribu
     """The state of the ev charger."""
 
     @classmethod
-    def from_proto(cls, raw: PbComponentData) -> Self:
+    def from_proto(cls, raw: microgrid_pb2.ComponentData) -> Self:
         """Create EVChargerData from a protobuf message.
 
         Args:

--- a/src/frequenz/client/microgrid/_component_data.py
+++ b/src/frequenz/client/microgrid/_component_data.py
@@ -8,12 +8,9 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Self
 
-# pylint: disable=no-name-in-module
 from frequenz.api.microgrid.microgrid_pb2 import ComponentData as PbComponentData
 
 from ._component_error import BatteryError, InverterError
-
-# pylint: enable=no-name-in-module
 from ._component_states import (
     BatteryComponentState,
     BatteryRelayState,

--- a/src/frequenz/client/microgrid/_component_error.py
+++ b/src/frequenz/client/microgrid/_component_error.py
@@ -7,27 +7,23 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Self
 
-from frequenz.api.microgrid.battery_pb2 import Error as PbBatteryError
-from frequenz.api.microgrid.battery_pb2 import ErrorCode as PbBatteryErrorCode
-from frequenz.api.microgrid.common_pb2 import ErrorLevel as PbErrorLevel
-from frequenz.api.microgrid.inverter_pb2 import Error as PbInverterError
-from frequenz.api.microgrid.inverter_pb2 import ErrorCode as PbInverterErrorCode
+from frequenz.api.microgrid import battery_pb2, common_pb2, inverter_pb2
 
 
 class ErrorLevel(Enum):
     """Error level."""
 
-    UNSPECIFIED = PbErrorLevel.ERROR_LEVEL_UNSPECIFIED
+    UNSPECIFIED = common_pb2.ErrorLevel.ERROR_LEVEL_UNSPECIFIED
     """Unspecified component error."""
 
-    WARN = PbErrorLevel.ERROR_LEVEL_WARN
+    WARN = common_pb2.ErrorLevel.ERROR_LEVEL_WARN
     """Action must be taken to prevent a severe error from occurring in the future."""
 
-    CRITICAL = PbErrorLevel.ERROR_LEVEL_CRITICAL
+    CRITICAL = common_pb2.ErrorLevel.ERROR_LEVEL_CRITICAL
     """A severe error that causes the component to fail. Immediate action must be taken."""
 
     @classmethod
-    def from_pb(cls, code: PbErrorLevel.ValueType) -> Self:
+    def from_pb(cls, code: common_pb2.ErrorLevel.ValueType) -> Self:
         """Convert a protobuf error level value to this enum.
 
         Args:
@@ -45,78 +41,82 @@ class ErrorLevel(Enum):
 class BatteryErrorCode(Enum):
     """Battery error code."""
 
-    UNSPECIFIED = PbBatteryErrorCode.ERROR_CODE_UNSPECIFIED
+    UNSPECIFIED = battery_pb2.ErrorCode.ERROR_CODE_UNSPECIFIED
     """Unspecified battery error code."""
 
-    HIGH_CURRENT_CHARGE = PbBatteryErrorCode.ERROR_CODE_HIGH_CURRENT_CHARGE
+    HIGH_CURRENT_CHARGE = battery_pb2.ErrorCode.ERROR_CODE_HIGH_CURRENT_CHARGE
     """Charge current is too high."""
 
-    HIGH_CURRENT_DISCHARGE = PbBatteryErrorCode.ERROR_CODE_HIGH_CURRENT_DISCHARGE
+    HIGH_CURRENT_DISCHARGE = battery_pb2.ErrorCode.ERROR_CODE_HIGH_CURRENT_DISCHARGE
     """Discharge current is too high."""
 
-    HIGH_VOLTAGE = PbBatteryErrorCode.ERROR_CODE_HIGH_VOLTAGE
+    HIGH_VOLTAGE = battery_pb2.ErrorCode.ERROR_CODE_HIGH_VOLTAGE
     """Voltage is too high."""
 
-    LOW_VOLTAGE = PbBatteryErrorCode.ERROR_CODE_LOW_VOLTAGE
+    LOW_VOLTAGE = battery_pb2.ErrorCode.ERROR_CODE_LOW_VOLTAGE
     """Voltage is too low."""
 
-    HIGH_TEMPERATURE = PbBatteryErrorCode.ERROR_CODE_HIGH_TEMPERATURE
+    HIGH_TEMPERATURE = battery_pb2.ErrorCode.ERROR_CODE_HIGH_TEMPERATURE
     """Temperature is too high."""
 
-    LOW_TEMPERATURE = PbBatteryErrorCode.ERROR_CODE_LOW_TEMPERATURE
+    LOW_TEMPERATURE = battery_pb2.ErrorCode.ERROR_CODE_LOW_TEMPERATURE
     """Temperature is too low."""
 
-    HIGH_HUMIDITY = PbBatteryErrorCode.ERROR_CODE_HIGH_HUMIDITY
+    HIGH_HUMIDITY = battery_pb2.ErrorCode.ERROR_CODE_HIGH_HUMIDITY
     """Humidity is too high."""
 
-    EXCEEDED_SOP_CHARGE = PbBatteryErrorCode.ERROR_CODE_EXCEEDED_SOP_CHARGE
+    EXCEEDED_SOP_CHARGE = battery_pb2.ErrorCode.ERROR_CODE_EXCEEDED_SOP_CHARGE
     """Charge current has exceeded component bounds."""
 
-    EXCEEDED_SOP_DISCHARGE = PbBatteryErrorCode.ERROR_CODE_EXCEEDED_SOP_DISCHARGE
+    EXCEEDED_SOP_DISCHARGE = battery_pb2.ErrorCode.ERROR_CODE_EXCEEDED_SOP_DISCHARGE
     """Discharge current has exceeded component bounds."""
 
-    SYSTEM_IMBALANCE = PbBatteryErrorCode.ERROR_CODE_SYSTEM_IMBALANCE
+    SYSTEM_IMBALANCE = battery_pb2.ErrorCode.ERROR_CODE_SYSTEM_IMBALANCE
     """The battery blocks are not balanced with respect to each other."""
 
-    LOW_SOH = PbBatteryErrorCode.ERROR_CODE_LOW_SOH
+    LOW_SOH = battery_pb2.ErrorCode.ERROR_CODE_LOW_SOH
     """The State of health is low."""
 
-    BLOCK_ERROR = PbBatteryErrorCode.ERROR_CODE_BLOCK_ERROR
+    BLOCK_ERROR = battery_pb2.ErrorCode.ERROR_CODE_BLOCK_ERROR
     """One or more battery blocks have failed."""
 
-    CONTROLLER_ERROR = PbBatteryErrorCode.ERROR_CODE_CONTROLLER_ERROR
+    CONTROLLER_ERROR = battery_pb2.ErrorCode.ERROR_CODE_CONTROLLER_ERROR
     """The battery controller has failed."""
 
-    RELAY_ERROR = PbBatteryErrorCode.ERROR_CODE_RELAY_ERROR
+    RELAY_ERROR = battery_pb2.ErrorCode.ERROR_CODE_RELAY_ERROR
     """The battery's DC relays have failed."""
 
-    RELAY_CYCLE_LIMIT_REACHED = PbBatteryErrorCode.ERROR_CODE_RELAY_CYCLE_LIMIT_REACHED
+    RELAY_CYCLE_LIMIT_REACHED = (
+        battery_pb2.ErrorCode.ERROR_CODE_RELAY_CYCLE_LIMIT_REACHED
+    )
     """The battery's DC relays have reached the cycles limit in its lifetime specifications."""
 
-    FUSE_ERROR = PbBatteryErrorCode.ERROR_CODE_FUSE_ERROR
+    FUSE_ERROR = battery_pb2.ErrorCode.ERROR_CODE_FUSE_ERROR
     """The battery's fuse has failed."""
 
     EXTERNAL_POWER_SWITCH_ERROR = (
-        PbBatteryErrorCode.ERROR_CODE_EXTERNAL_POWER_SWITCH_ERROR
+        battery_pb2.ErrorCode.ERROR_CODE_EXTERNAL_POWER_SWITCH_ERROR
     )
     """The eternal power switch has failed."""
 
-    PRECHARGE_ERROR = PbBatteryErrorCode.ERROR_CODE_PRECHARGE_ERROR
+    PRECHARGE_ERROR = battery_pb2.ErrorCode.ERROR_CODE_PRECHARGE_ERROR
     """The precharge operation has failed."""
 
-    SYSTEM_PLAUSIBILITY_ERROR = PbBatteryErrorCode.ERROR_CODE_SYSTEM_PLAUSIBILITY_ERROR
+    SYSTEM_PLAUSIBILITY_ERROR = (
+        battery_pb2.ErrorCode.ERROR_CODE_SYSTEM_PLAUSIBILITY_ERROR
+    )
     """System plausibility checks have failed."""
 
     SYSTEM_UNDERVOLTAGE_SHUTDOWN = (
-        PbBatteryErrorCode.ERROR_CODE_SYSTEM_UNDERVOLTAGE_SHUTDOWN
+        battery_pb2.ErrorCode.ERROR_CODE_SYSTEM_UNDERVOLTAGE_SHUTDOWN
     )
     """System shut down due to extremely low voltage."""
 
-    CALIBRATION_NEEDED = PbBatteryErrorCode.ERROR_CODE_CALIBRATION_NEEDED
+    CALIBRATION_NEEDED = battery_pb2.ErrorCode.ERROR_CODE_CALIBRATION_NEEDED
     """The battery requires a calibration to reset its measurements."""
 
     @classmethod
-    def from_pb(cls, code: PbBatteryErrorCode.ValueType) -> Self:
+    def from_pb(cls, code: battery_pb2.ErrorCode.ValueType) -> Self:
         """Convert a protobuf error code value to this enum.
 
         Args:
@@ -145,7 +145,7 @@ class BatteryError:
     """The error message."""
 
     @classmethod
-    def from_pb(cls, raw: PbBatteryError) -> Self:
+    def from_pb(cls, raw: battery_pb2.Error) -> Self:
         """Create a new instance using a protobuf message to get the values.
 
         Args:
@@ -164,11 +164,11 @@ class BatteryError:
 class InverterErrorCode(Enum):
     """Inverter error code."""
 
-    UNSPECIFIED = PbInverterErrorCode.ERROR_CODE_UNSPECIFIED
+    UNSPECIFIED = inverter_pb2.ErrorCode.ERROR_CODE_UNSPECIFIED
     """Unspecified inverter error code."""
 
     @classmethod
-    def from_pb(cls, code: PbInverterErrorCode.ValueType) -> Self:
+    def from_pb(cls, code: inverter_pb2.ErrorCode.ValueType) -> Self:
         """Convert a protobuf error code value to this enum.
 
         Args:
@@ -197,7 +197,7 @@ class InverterError:
     """The error message."""
 
     @classmethod
-    def from_pb(cls, raw: PbInverterError) -> Self:
+    def from_pb(cls, raw: inverter_pb2.Error) -> Self:
         """Create a new instance using a protobuf message to get the values.
 
         Args:

--- a/src/frequenz/client/microgrid/_component_error.py
+++ b/src/frequenz/client/microgrid/_component_error.py
@@ -7,14 +7,11 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Self
 
-# pylint: disable=no-name-in-module
 from frequenz.api.microgrid.battery_pb2 import Error as PbBatteryError
 from frequenz.api.microgrid.battery_pb2 import ErrorCode as PbBatteryErrorCode
 from frequenz.api.microgrid.common_pb2 import ErrorLevel as PbErrorLevel
 from frequenz.api.microgrid.inverter_pb2 import Error as PbInverterError
 from frequenz.api.microgrid.inverter_pb2 import ErrorCode as PbInverterErrorCode
-
-# pylint: enable=no-name-in-module
 
 
 class ErrorLevel(Enum):

--- a/src/frequenz/client/microgrid/_component_states.py
+++ b/src/frequenz/client/microgrid/_component_states.py
@@ -6,55 +6,49 @@
 from enum import Enum
 from typing import Self
 
-from frequenz.api.microgrid.battery_pb2 import ComponentState as PbBatteryComponentState
-from frequenz.api.microgrid.battery_pb2 import RelayState as PbBatteryRelayState
-from frequenz.api.microgrid.ev_charger_pb2 import CableState as PbEvCableState
-from frequenz.api.microgrid.ev_charger_pb2 import ComponentState as PbEvComponentState
-from frequenz.api.microgrid.inverter_pb2 import (
-    ComponentState as PbInverterComponentState,
-)
+from frequenz.api.microgrid import battery_pb2, ev_charger_pb2, inverter_pb2
 
 
 class BatteryComponentState(Enum):
     """Component states of a battery."""
 
-    UNSPECIFIED = PbBatteryComponentState.COMPONENT_STATE_UNSPECIFIED
+    UNSPECIFIED = battery_pb2.ComponentState.COMPONENT_STATE_UNSPECIFIED
     """Unspecified component state."""
 
-    OFF = PbBatteryComponentState.COMPONENT_STATE_OFF
+    OFF = battery_pb2.ComponentState.COMPONENT_STATE_OFF
     """The battery is switched off."""
 
-    IDLE = PbBatteryComponentState.COMPONENT_STATE_IDLE
+    IDLE = battery_pb2.ComponentState.COMPONENT_STATE_IDLE
     """The battery is idle."""
 
-    CHARGING = PbBatteryComponentState.COMPONENT_STATE_CHARGING
+    CHARGING = battery_pb2.ComponentState.COMPONENT_STATE_CHARGING
     """The battery is consuming electrical energy."""
 
-    DISCHARGING = PbBatteryComponentState.COMPONENT_STATE_DISCHARGING
+    DISCHARGING = battery_pb2.ComponentState.COMPONENT_STATE_DISCHARGING
     """The battery is generating electrical energy."""
 
-    ERROR = PbBatteryComponentState.COMPONENT_STATE_ERROR
+    ERROR = battery_pb2.ComponentState.COMPONENT_STATE_ERROR
     """The battery is in a faulty state."""
 
-    LOCKED = PbBatteryComponentState.COMPONENT_STATE_LOCKED
+    LOCKED = battery_pb2.ComponentState.COMPONENT_STATE_LOCKED
     """The battery is online, but currently unavailable.
 
     Possibly due to a pre-scheduled maintenance, or waiting for a resource to be loaded.
     """
 
-    SWITCHING_ON = PbBatteryComponentState.COMPONENT_STATE_SWITCHING_ON
+    SWITCHING_ON = battery_pb2.ComponentState.COMPONENT_STATE_SWITCHING_ON
     """
     The battery is starting up and needs some time to become fully operational.
     """
 
-    SWITCHING_OFF = PbBatteryComponentState.COMPONENT_STATE_SWITCHING_OFF
+    SWITCHING_OFF = battery_pb2.ComponentState.COMPONENT_STATE_SWITCHING_OFF
     """The battery is switching off and needs some time to fully shut down."""
 
-    UNKNOWN = PbBatteryComponentState.COMPONENT_STATE_UNKNOWN
+    UNKNOWN = battery_pb2.ComponentState.COMPONENT_STATE_UNKNOWN
     """A state is provided by the component, but it is not one of the above states."""
 
     @classmethod
-    def from_pb(cls, state: PbBatteryComponentState.ValueType) -> Self:
+    def from_pb(cls, state: battery_pb2.ComponentState.ValueType) -> Self:
         """Convert a protobuf state value to this enum.
 
         Args:
@@ -72,26 +66,26 @@ class BatteryComponentState(Enum):
 class BatteryRelayState(Enum):
     """Relay states of a battery."""
 
-    UNSPECIFIED = PbBatteryRelayState.RELAY_STATE_UNSPECIFIED
+    UNSPECIFIED = battery_pb2.RelayState.RELAY_STATE_UNSPECIFIED
     """Unspecified relay state."""
 
-    OPENED = PbBatteryRelayState.RELAY_STATE_OPENED
+    OPENED = battery_pb2.RelayState.RELAY_STATE_OPENED
     """The relays are open, and the DC power line to the inverter is disconnected."""
 
-    PRECHARGING = PbBatteryRelayState.RELAY_STATE_PRECHARGING
+    PRECHARGING = battery_pb2.RelayState.RELAY_STATE_PRECHARGING
     """The relays are closing, and the DC power line to the inverter is being connected."""
 
-    CLOSED = PbBatteryRelayState.RELAY_STATE_CLOSED
+    CLOSED = battery_pb2.RelayState.RELAY_STATE_CLOSED
     """The relays are closed, and the DC power line to the inverter is connected."""
 
-    ERROR = PbBatteryRelayState.RELAY_STATE_ERROR
+    ERROR = battery_pb2.RelayState.RELAY_STATE_ERROR
     """The relays are in an error state."""
 
-    LOCKED = PbBatteryRelayState.RELAY_STATE_LOCKED
+    LOCKED = battery_pb2.RelayState.RELAY_STATE_LOCKED
     """The relays are locked, and should be available to accept commands shortly."""
 
     @classmethod
-    def from_pb(cls, state: PbBatteryRelayState.ValueType) -> Self:
+    def from_pb(cls, state: battery_pb2.RelayState.ValueType) -> Self:
         """Convert a protobuf state value to this enum.
 
         Args:
@@ -109,26 +103,30 @@ class BatteryRelayState(Enum):
 class EVChargerCableState(Enum):
     """Cable states of an EV Charger."""
 
-    UNSPECIFIED = PbEvCableState.CABLE_STATE_UNSPECIFIED
+    UNSPECIFIED = ev_charger_pb2.CableState.CABLE_STATE_UNSPECIFIED
     """Unspecified cable state."""
 
-    UNPLUGGED = PbEvCableState.CABLE_STATE_UNPLUGGED
+    UNPLUGGED = ev_charger_pb2.CableState.CABLE_STATE_UNPLUGGED
     """The cable is unplugged."""
 
-    CHARGING_STATION_PLUGGED = PbEvCableState.CABLE_STATE_CHARGING_STATION_PLUGGED
+    CHARGING_STATION_PLUGGED = (
+        ev_charger_pb2.CableState.CABLE_STATE_CHARGING_STATION_PLUGGED
+    )
     """The cable is plugged into the charging station."""
 
-    CHARGING_STATION_LOCKED = PbEvCableState.CABLE_STATE_CHARGING_STATION_LOCKED
+    CHARGING_STATION_LOCKED = (
+        ev_charger_pb2.CableState.CABLE_STATE_CHARGING_STATION_LOCKED
+    )
     """The cable is plugged into the charging station and locked."""
 
-    EV_PLUGGED = PbEvCableState.CABLE_STATE_EV_PLUGGED
+    EV_PLUGGED = ev_charger_pb2.CableState.CABLE_STATE_EV_PLUGGED
     """The cable is plugged into the EV."""
 
-    EV_LOCKED = PbEvCableState.CABLE_STATE_EV_LOCKED
+    EV_LOCKED = ev_charger_pb2.CableState.CABLE_STATE_EV_LOCKED
     """The cable is plugged into the EV and locked."""
 
     @classmethod
-    def from_pb(cls, state: PbEvCableState.ValueType) -> Self:
+    def from_pb(cls, state: ev_charger_pb2.CableState.ValueType) -> Self:
         """Convert a protobuf state value to this enum.
 
         Args:
@@ -146,38 +144,40 @@ class EVChargerCableState(Enum):
 class EVChargerComponentState(Enum):
     """Component State of an EV Charger."""
 
-    UNSPECIFIED = PbEvComponentState.COMPONENT_STATE_UNSPECIFIED
+    UNSPECIFIED = ev_charger_pb2.ComponentState.COMPONENT_STATE_UNSPECIFIED
     """Unspecified component state."""
 
-    STARTING = PbEvComponentState.COMPONENT_STATE_STARTING
+    STARTING = ev_charger_pb2.ComponentState.COMPONENT_STATE_STARTING
     """The component is starting."""
 
-    NOT_READY = PbEvComponentState.COMPONENT_STATE_NOT_READY
+    NOT_READY = ev_charger_pb2.ComponentState.COMPONENT_STATE_NOT_READY
     """The component is not ready."""
 
-    READY = PbEvComponentState.COMPONENT_STATE_READY
+    READY = ev_charger_pb2.ComponentState.COMPONENT_STATE_READY
     """The component is ready."""
 
-    CHARGING = PbEvComponentState.COMPONENT_STATE_CHARGING
+    CHARGING = ev_charger_pb2.ComponentState.COMPONENT_STATE_CHARGING
     """The component is charging."""
 
-    DISCHARGING = PbEvComponentState.COMPONENT_STATE_DISCHARGING
+    DISCHARGING = ev_charger_pb2.ComponentState.COMPONENT_STATE_DISCHARGING
     """The component is discharging."""
 
-    ERROR = PbEvComponentState.COMPONENT_STATE_ERROR
+    ERROR = ev_charger_pb2.ComponentState.COMPONENT_STATE_ERROR
     """The component is in error state."""
 
-    AUTHORIZATION_REJECTED = PbEvComponentState.COMPONENT_STATE_AUTHORIZATION_REJECTED
+    AUTHORIZATION_REJECTED = (
+        ev_charger_pb2.ComponentState.COMPONENT_STATE_AUTHORIZATION_REJECTED
+    )
     """The component rejected authorization."""
 
-    INTERRUPTED = PbEvComponentState.COMPONENT_STATE_INTERRUPTED
+    INTERRUPTED = ev_charger_pb2.ComponentState.COMPONENT_STATE_INTERRUPTED
     """The component is interrupted."""
 
-    UNKNOWN = PbEvComponentState.COMPONENT_STATE_UNKNOWN
+    UNKNOWN = ev_charger_pb2.ComponentState.COMPONENT_STATE_UNKNOWN
     """A state is provided by the component, but it is not one of the above states."""
 
     @classmethod
-    def from_pb(cls, state: PbEvComponentState.ValueType) -> Self:
+    def from_pb(cls, state: ev_charger_pb2.ComponentState.ValueType) -> Self:
         """Convert a protobuf state value to this enum.
 
         Args:
@@ -195,50 +195,50 @@ class EVChargerComponentState(Enum):
 class InverterComponentState(Enum):
     """Component states of an inverter."""
 
-    UNSPECIFIED = PbInverterComponentState.COMPONENT_STATE_UNSPECIFIED
+    UNSPECIFIED = inverter_pb2.ComponentState.COMPONENT_STATE_UNSPECIFIED
     """Unspecified component state."""
 
-    OFF = PbInverterComponentState.COMPONENT_STATE_OFF
+    OFF = inverter_pb2.ComponentState.COMPONENT_STATE_OFF
     """Inverter is switched off."""
 
-    SWITCHING_ON = PbInverterComponentState.COMPONENT_STATE_SWITCHING_ON
+    SWITCHING_ON = inverter_pb2.ComponentState.COMPONENT_STATE_SWITCHING_ON
     """The PbInverteris starting up and needs some time to become fully operational."""
 
-    SWITCHING_OFF = PbInverterComponentState.COMPONENT_STATE_SWITCHING_OFF
+    SWITCHING_OFF = inverter_pb2.ComponentState.COMPONENT_STATE_SWITCHING_OFF
     """The PbInverteris switching off and needs some time to fully shut down."""
 
-    STANDBY = PbInverterComponentState.COMPONENT_STATE_STANDBY
+    STANDBY = inverter_pb2.ComponentState.COMPONENT_STATE_STANDBY
     """The PbInverteris in a standby state, and is disconnected from the grid.
 
     When connected to the grid, it run a few tests, and move to the `IDLE` state.
     """
 
-    IDLE = PbInverterComponentState.COMPONENT_STATE_IDLE
+    IDLE = inverter_pb2.ComponentState.COMPONENT_STATE_IDLE
     """The inverter is idle."""
 
-    CHARGING = PbInverterComponentState.COMPONENT_STATE_CHARGING
+    CHARGING = inverter_pb2.ComponentState.COMPONENT_STATE_CHARGING
     """The inverter is consuming electrical energy to charge batteries.
 
     Applicable to `BATTERY` and `HYBRID` inverters only.
     """
 
-    DISCHARGING = PbInverterComponentState.COMPONENT_STATE_DISCHARGING
+    DISCHARGING = inverter_pb2.ComponentState.COMPONENT_STATE_DISCHARGING
     """The inverter is generating electrical energy."""
 
-    ERROR = PbInverterComponentState.COMPONENT_STATE_ERROR
+    ERROR = inverter_pb2.ComponentState.COMPONENT_STATE_ERROR
     """The inverter is in a faulty state."""
 
-    UNAVAILABLE = PbInverterComponentState.COMPONENT_STATE_UNAVAILABLE
+    UNAVAILABLE = inverter_pb2.ComponentState.COMPONENT_STATE_UNAVAILABLE
     """The inverter is online, but currently unavailable.
 
     Possibly due to a pre- scheduled maintenance.
     """
 
-    UNKNOWN = PbInverterComponentState.COMPONENT_STATE_UNKNOWN
+    UNKNOWN = inverter_pb2.ComponentState.COMPONENT_STATE_UNKNOWN
     """A state is provided by the component, but it is not one of the above states."""
 
     @classmethod
-    def from_pb(cls, state: PbInverterComponentState.ValueType) -> Self:
+    def from_pb(cls, state: inverter_pb2.ComponentState.ValueType) -> Self:
         """Convert a protobuf state value to this enum.
 
         Args:

--- a/src/frequenz/client/microgrid/_component_states.py
+++ b/src/frequenz/client/microgrid/_component_states.py
@@ -6,7 +6,6 @@
 from enum import Enum
 from typing import Self
 
-# pylint: disable=no-name-in-module
 from frequenz.api.microgrid.battery_pb2 import ComponentState as PbBatteryComponentState
 from frequenz.api.microgrid.battery_pb2 import RelayState as PbBatteryRelayState
 from frequenz.api.microgrid.ev_charger_pb2 import CableState as PbEvCableState
@@ -14,8 +13,6 @@ from frequenz.api.microgrid.ev_charger_pb2 import ComponentState as PbEvComponen
 from frequenz.api.microgrid.inverter_pb2 import (
     ComponentState as PbInverterComponentState,
 )
-
-# pylint: enable=no-name-in-module
 
 
 class BatteryComponentState(Enum):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,21 +11,8 @@ from unittest import mock
 
 import grpc.aio
 import pytest
-from frequenz.api.common.components_pb2 import ComponentCategory as PbComponentCategory
-from frequenz.api.common.components_pb2 import InverterType as PbInverterType
-from frequenz.api.common.metrics_pb2 import Bounds as PbBounds
-from frequenz.api.microgrid.grid_pb2 import Metadata as PbGridMetadata
-from frequenz.api.microgrid.inverter_pb2 import Metadata as PbInverterMetadata
-from frequenz.api.microgrid.microgrid_pb2 import Component as PbComponent
-from frequenz.api.microgrid.microgrid_pb2 import ComponentData as PbComponentData
-from frequenz.api.microgrid.microgrid_pb2 import ComponentList as PbComponentList
-from frequenz.api.microgrid.microgrid_pb2 import Connection as PbConnection
-from frequenz.api.microgrid.microgrid_pb2 import ConnectionFilter as PbConnectionFilter
-from frequenz.api.microgrid.microgrid_pb2 import ConnectionList as PbConnectionList
-from frequenz.api.microgrid.microgrid_pb2 import SetBoundsParam as PbSetBoundsParam
-from frequenz.api.microgrid.microgrid_pb2 import (
-    SetPowerActiveParam as PbSetPowerActiveParam,
-)
+from frequenz.api.common import components_pb2, metrics_pb2
+from frequenz.api.microgrid import grid_pb2, inverter_pb2, microgrid_pb2
 from frequenz.client.base import retry
 
 from frequenz.client.microgrid import (
@@ -65,17 +52,21 @@ class _TestClient(ApiClient):
 async def test_components() -> None:
     """Test the components() method."""
     client = _TestClient()
-    server_response = PbComponentList()
+    server_response = microgrid_pb2.ComponentList()
     client.mock_stub.ListComponents.return_value = server_response
     assert set(await client.components()) == set()
 
     server_response.components.append(
-        PbComponent(id=0, category=PbComponentCategory.COMPONENT_CATEGORY_METER)
+        microgrid_pb2.Component(
+            id=0, category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_METER
+        )
     )
     assert set(await client.components()) == {Component(0, ComponentCategory.METER)}
 
     server_response.components.append(
-        PbComponent(id=0, category=PbComponentCategory.COMPONENT_CATEGORY_BATTERY)
+        microgrid_pb2.Component(
+            id=0, category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_BATTERY
+        )
     )
     assert set(await client.components()) == {
         Component(0, ComponentCategory.METER),
@@ -83,7 +74,9 @@ async def test_components() -> None:
     }
 
     server_response.components.append(
-        PbComponent(id=0, category=PbComponentCategory.COMPONENT_CATEGORY_METER)
+        microgrid_pb2.Component(
+            id=0, category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_METER
+        )
     )
     assert set(await client.components()) == {
         Component(0, ComponentCategory.METER),
@@ -93,7 +86,9 @@ async def test_components() -> None:
 
     # sensors are not counted as components by the API client
     server_response.components.append(
-        PbComponent(id=1, category=PbComponentCategory.COMPONENT_CATEGORY_SENSOR)
+        microgrid_pb2.Component(
+            id=1, category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_SENSOR
+        )
     )
     assert set(await client.components()) == {
         Component(0, ComponentCategory.METER),
@@ -104,13 +99,20 @@ async def test_components() -> None:
     _replace_components(
         server_response,
         [
-            PbComponent(id=9, category=PbComponentCategory.COMPONENT_CATEGORY_METER),
-            PbComponent(
-                id=99, category=PbComponentCategory.COMPONENT_CATEGORY_INVERTER
+            microgrid_pb2.Component(
+                id=9, category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_METER
             ),
-            PbComponent(id=666, category=PbComponentCategory.COMPONENT_CATEGORY_SENSOR),
-            PbComponent(
-                id=999, category=PbComponentCategory.COMPONENT_CATEGORY_BATTERY
+            microgrid_pb2.Component(
+                id=99,
+                category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_INVERTER,
+            ),
+            microgrid_pb2.Component(
+                id=666,
+                category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_SENSOR,
+            ),
+            microgrid_pb2.Component(
+                id=999,
+                category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_BATTERY,
             ),
         ],
     )
@@ -123,28 +125,38 @@ async def test_components() -> None:
     _replace_components(
         server_response,
         [
-            PbComponent(id=99, category=PbComponentCategory.COMPONENT_CATEGORY_SENSOR),
-            PbComponent(
+            microgrid_pb2.Component(
+                id=99,
+                category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_SENSOR,
+            ),
+            microgrid_pb2.Component(
                 id=100,
-                category=PbComponentCategory.COMPONENT_CATEGORY_UNSPECIFIED,
+                category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_UNSPECIFIED,
             ),
-            PbComponent(id=104, category=PbComponentCategory.COMPONENT_CATEGORY_METER),
-            PbComponent(
+            microgrid_pb2.Component(
+                id=104,
+                category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_METER,
+            ),
+            microgrid_pb2.Component(
                 id=105,
-                category=PbComponentCategory.COMPONENT_CATEGORY_INVERTER,
+                category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_INVERTER,
             ),
-            PbComponent(
-                id=106, category=PbComponentCategory.COMPONENT_CATEGORY_BATTERY
+            microgrid_pb2.Component(
+                id=106,
+                category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_BATTERY,
             ),
-            PbComponent(
+            microgrid_pb2.Component(
                 id=107,
-                category=PbComponentCategory.COMPONENT_CATEGORY_EV_CHARGER,
+                category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_EV_CHARGER,
             ),
-            PbComponent(id=999, category=PbComponentCategory.COMPONENT_CATEGORY_SENSOR),
-            PbComponent(
+            microgrid_pb2.Component(
+                id=999,
+                category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_SENSOR,
+            ),
+            microgrid_pb2.Component(
                 id=101,
-                category=PbComponentCategory.COMPONENT_CATEGORY_GRID,
-                grid=PbGridMetadata(rated_fuse_current=int(123.0)),
+                category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_GRID,
+                grid=grid_pb2.Metadata(rated_fuse_current=int(123.0)),
             ),
         ],
     )
@@ -168,15 +180,23 @@ async def test_components() -> None:
     _replace_components(
         server_response,
         [
-            PbComponent(id=9, category=PbComponentCategory.COMPONENT_CATEGORY_METER),
-            PbComponent(id=666, category=PbComponentCategory.COMPONENT_CATEGORY_SENSOR),
-            PbComponent(
-                id=999, category=PbComponentCategory.COMPONENT_CATEGORY_BATTERY
+            microgrid_pb2.Component(
+                id=9, category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_METER
             ),
-            PbComponent(
+            microgrid_pb2.Component(
+                id=666,
+                category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_SENSOR,
+            ),
+            microgrid_pb2.Component(
+                id=999,
+                category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_BATTERY,
+            ),
+            microgrid_pb2.Component(
                 id=99,
-                category=PbComponentCategory.COMPONENT_CATEGORY_INVERTER,
-                inverter=PbInverterMetadata(type=PbInverterType.INVERTER_TYPE_BATTERY),
+                category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_INVERTER,
+                inverter=inverter_pb2.Metadata(
+                    type=components_pb2.InverterType.INVERTER_TYPE_BATTERY
+                ),
             ),
         ],
     )
@@ -214,33 +234,39 @@ async def test_connections() -> None:
     def assert_filter(*, starts: set[int], ends: set[int]) -> None:
         client.mock_stub.ListConnections.assert_called_once()
         filter_ = client.mock_stub.ListConnections.call_args[0][0]
-        assert isinstance(filter_, PbConnectionFilter)
+        assert isinstance(filter_, microgrid_pb2.ConnectionFilter)
         assert set(filter_.starts) == starts
         assert set(filter_.ends) == ends
 
-    components_response = PbComponentList()
-    connections_response = PbConnectionList()
+    components_response = microgrid_pb2.ComponentList()
+    connections_response = microgrid_pb2.ConnectionList()
     client.mock_stub.ListComponents.return_value = components_response
     client.mock_stub.ListConnections.return_value = connections_response
     assert set(await client.connections()) == set()
     assert_filter(starts=set(), ends=set())
 
-    connections_response.connections.append(PbConnection(start=0, end=0))
+    connections_response.connections.append(microgrid_pb2.Connection(start=0, end=0))
     assert set(await client.connections()) == {Connection(0, 0)}
 
     components_response.components.extend(
         [
-            PbComponent(id=7, category=PbComponentCategory.COMPONENT_CATEGORY_BATTERY),
-            PbComponent(id=9, category=PbComponentCategory.COMPONENT_CATEGORY_INVERTER),
+            microgrid_pb2.Component(
+                id=7,
+                category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_BATTERY,
+            ),
+            microgrid_pb2.Component(
+                id=9,
+                category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_INVERTER,
+            ),
         ]
     )
-    connections_response.connections.append(PbConnection(start=7, end=9))
+    connections_response.connections.append(microgrid_pb2.Connection(start=7, end=9))
     assert set(await client.connections()) == {
         Connection(0, 0),
         Connection(7, 9),
     }
 
-    connections_response.connections.append(PbConnection(start=0, end=0))
+    connections_response.connections.append(microgrid_pb2.Connection(start=0, end=0))
     assert set(await client.connections()) == {
         Connection(0, 0),
         Connection(7, 9),
@@ -250,17 +276,17 @@ async def test_connections() -> None:
     _replace_connections(
         connections_response,
         [
-            PbConnection(start=999, end=9),
-            PbConnection(start=99, end=19),
-            PbConnection(start=909, end=101),
-            PbConnection(start=99, end=91),
+            microgrid_pb2.Connection(start=999, end=9),
+            microgrid_pb2.Connection(start=99, end=19),
+            microgrid_pb2.Connection(start=909, end=101),
+            microgrid_pb2.Connection(start=99, end=91),
         ],
     )
     for component_id in [999, 99, 19, 909, 101, 91]:
         components_response.components.append(
-            PbComponent(
+            microgrid_pb2.Component(
                 id=component_id,
-                category=PbComponentCategory.COMPONENT_CATEGORY_BATTERY,
+                category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_BATTERY,
             )
         )
     assert set(await client.connections()) == {
@@ -272,24 +298,24 @@ async def test_connections() -> None:
 
     for component_id in [1, 2, 3, 4, 5, 6, 7, 8]:
         components_response.components.append(
-            PbComponent(
+            microgrid_pb2.Component(
                 id=component_id,
-                category=PbComponentCategory.COMPONENT_CATEGORY_BATTERY,
+                category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_BATTERY,
             )
         )
     _replace_connections(
         connections_response,
         [
-            PbConnection(start=1, end=2),
-            PbConnection(start=2, end=3),
-            PbConnection(start=2, end=4),
-            PbConnection(start=2, end=5),
-            PbConnection(start=4, end=3),
-            PbConnection(start=4, end=5),
-            PbConnection(start=4, end=6),
-            PbConnection(start=5, end=4),
-            PbConnection(start=5, end=7),
-            PbConnection(start=5, end=8),
+            microgrid_pb2.Connection(start=1, end=2),
+            microgrid_pb2.Connection(start=2, end=3),
+            microgrid_pb2.Connection(start=2, end=4),
+            microgrid_pb2.Connection(start=2, end=5),
+            microgrid_pb2.Connection(start=4, end=3),
+            microgrid_pb2.Connection(start=4, end=5),
+            microgrid_pb2.Connection(start=4, end=6),
+            microgrid_pb2.Connection(start=5, end=4),
+            microgrid_pb2.Connection(start=5, end=7),
+            microgrid_pb2.Connection(start=5, end=8),
         ],
     )
     assert set(await client.connections()) == {
@@ -355,38 +381,44 @@ async def test_connections_grpc_error() -> None:
 
 
 @pytest.fixture
-def meter83() -> PbComponent:
+def meter83() -> microgrid_pb2.Component:
     """Return a test meter component."""
-    return PbComponent(id=83, category=PbComponentCategory.COMPONENT_CATEGORY_METER)
+    return microgrid_pb2.Component(
+        id=83, category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_METER
+    )
 
 
 @pytest.fixture
-def battery38() -> PbComponent:
+def battery38() -> microgrid_pb2.Component:
     """Return a test battery component."""
-    return PbComponent(id=38, category=PbComponentCategory.COMPONENT_CATEGORY_BATTERY)
+    return microgrid_pb2.Component(
+        id=38, category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_BATTERY
+    )
 
 
 @pytest.fixture
-def inverter99() -> PbComponent:
+def inverter99() -> microgrid_pb2.Component:
     """Return a test inverter component."""
-    return PbComponent(id=99, category=PbComponentCategory.COMPONENT_CATEGORY_INVERTER)
+    return microgrid_pb2.Component(
+        id=99, category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_INVERTER
+    )
 
 
 @pytest.fixture
-def ev_charger101() -> PbComponent:
+def ev_charger101() -> microgrid_pb2.Component:
     """Return a test EV charger component."""
-    return PbComponent(
-        id=101, category=PbComponentCategory.COMPONENT_CATEGORY_EV_CHARGER
+    return microgrid_pb2.Component(
+        id=101, category=components_pb2.ComponentCategory.COMPONENT_CATEGORY_EV_CHARGER
     )
 
 
 @pytest.fixture
 def component_list(
-    meter83: PbComponent,
-    battery38: PbComponent,
-    inverter99: PbComponent,
-    ev_charger101: PbComponent,
-) -> list[PbComponent]:
+    meter83: microgrid_pb2.Component,
+    battery38: microgrid_pb2.Component,
+    inverter99: microgrid_pb2.Component,
+    ev_charger101: microgrid_pb2.Component,
+) -> list[microgrid_pb2.Component]:
     """Return a list of test components."""
     return [meter83, battery38, inverter99, ev_charger101]
 
@@ -395,7 +427,7 @@ def component_list(
 async def test_data_component_not_found(method: str) -> None:
     """Test the meter_data() method."""
     client = _TestClient()
-    client.mock_stub.ListComponents.return_value = PbComponentList()
+    client.mock_stub.ListComponents.return_value = microgrid_pb2.ComponentList()
 
     # It should raise a ValueError for a missing component_id
     with pytest.raises(ValueError, match="Unable to find component with id 20"):
@@ -412,11 +444,11 @@ async def test_data_component_not_found(method: str) -> None:
     ],
 )
 async def test_data_bad_category(
-    method: str, component_id: int, component_list: list[PbComponent]
+    method: str, component_id: int, component_list: list[microgrid_pb2.Component]
 ) -> None:
     """Test the meter_data() method."""
     client = _TestClient()
-    client.mock_stub.ListComponents.return_value = PbComponentList(
+    client.mock_stub.ListComponents.return_value = microgrid_pb2.ComponentList(
         components=component_list
     )
 
@@ -440,18 +472,18 @@ async def test_component_data(
     method: str,
     component_id: int,
     component_class: type[ComponentData],
-    component_list: list[PbComponent],
+    component_list: list[microgrid_pb2.Component],
 ) -> None:
     """Test the meter_data() method."""
     client = _TestClient()
-    client.mock_stub.ListComponents.return_value = PbComponentList(
+    client.mock_stub.ListComponents.return_value = microgrid_pb2.ComponentList(
         components=component_list
     )
 
     async def stream_data(
         *args: Any, **kwargs: Any  # pylint: disable=unused-argument
-    ) -> AsyncIterator[PbComponentData]:
-        yield PbComponentData(id=component_id)
+    ) -> AsyncIterator[microgrid_pb2.ComponentData]:
+        yield microgrid_pb2.ComponentData(id=component_id)
 
     client.mock_stub.StreamComponentData.side_effect = stream_data
     receiver = await getattr(client, method)(component_id)
@@ -477,7 +509,7 @@ async def test_component_data_grpc_error(
     method: str,
     component_id: int,
     component_class: type[ComponentData],
-    component_list: list[PbComponent],
+    component_list: list[microgrid_pb2.Component],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test the components() method when the gRPC call fails."""
@@ -485,7 +517,7 @@ async def test_component_data_grpc_error(
     client = _TestClient(
         retry_strategy=retry.LinearBackoff(interval=0.0, jitter=0.0, limit=6)
     )
-    client.mock_stub.ListComponents.return_value = PbComponentList(
+    client.mock_stub.ListComponents.return_value = microgrid_pb2.ComponentList(
         components=component_list
     )
 
@@ -493,7 +525,7 @@ async def test_component_data_grpc_error(
 
     async def stream_data(
         *args: Any, **kwargs: Any  # pylint: disable=unused-argument
-    ) -> AsyncIterator[PbComponentData]:
+    ) -> AsyncIterator[microgrid_pb2.ComponentData]:
         nonlocal num_calls
         num_calls += 1
         if num_calls % 2:
@@ -504,7 +536,7 @@ async def test_component_data_grpc_error(
                 f"fake grpc details num_calls={num_calls}",
                 "fake grpc debug_error_string",
             )
-        yield PbComponentData(id=component_id)
+        yield microgrid_pb2.ComponentData(id=component_id)
 
     client.mock_stub.StreamComponentData.side_effect = stream_data
     receiver = await getattr(client, method)(component_id)
@@ -541,15 +573,19 @@ async def test_component_data_grpc_error(
 
 
 @pytest.mark.parametrize("power_w", [0, 0.0, 12, -75, 0.1, -0.0001, 134.0])
-async def test_set_power_ok(power_w: float, meter83: PbComponent) -> None:
+async def test_set_power_ok(power_w: float, meter83: microgrid_pb2.Component) -> None:
     """Test if charge is able to charge component."""
     client = _TestClient()
-    client.mock_stub.ListComponents.return_value = PbComponentList(components=[meter83])
+    client.mock_stub.ListComponents.return_value = microgrid_pb2.ComponentList(
+        components=[meter83]
+    )
 
     await client.set_power(component_id=83, power_w=power_w)
     client.mock_stub.SetPowerActive.assert_called_once()
     call_args = client.mock_stub.SetPowerActive.call_args[0]
-    assert call_args[0] == PbSetPowerActiveParam(component_id=83, power=power_w)
+    assert call_args[0] == microgrid_pb2.SetPowerActiveParam(
+        component_id=83, power=power_w
+    )
 
 
 async def test_set_power_grpc_error() -> None:
@@ -574,26 +610,28 @@ async def test_set_power_grpc_error() -> None:
 @pytest.mark.parametrize(
     "bounds",
     [
-        PbBounds(lower=0.0, upper=0.0),
-        PbBounds(lower=0.0, upper=2.0),
-        PbBounds(lower=-10.0, upper=0.0),
-        PbBounds(lower=-10.0, upper=2.0),
+        metrics_pb2.Bounds(lower=0.0, upper=0.0),
+        metrics_pb2.Bounds(lower=0.0, upper=2.0),
+        metrics_pb2.Bounds(lower=-10.0, upper=0.0),
+        metrics_pb2.Bounds(lower=-10.0, upper=2.0),
     ],
     ids=str,
 )
-async def test_set_bounds_ok(bounds: PbBounds, inverter99: PbComponent) -> None:
+async def test_set_bounds_ok(
+    bounds: metrics_pb2.Bounds, inverter99: microgrid_pb2.Component
+) -> None:
     """Test if charge is able to charge component."""
     client = _TestClient()
-    client.mock_stub.ListComponents.return_value = PbComponentList(
+    client.mock_stub.ListComponents.return_value = microgrid_pb2.ComponentList(
         components=[inverter99]
     )
 
     await client.set_bounds(99, bounds.lower, bounds.upper)
     client.mock_stub.AddInclusionBounds.assert_called_once()
     call_args = client.mock_stub.AddInclusionBounds.call_args[0]
-    assert call_args[0] == PbSetBoundsParam(
+    assert call_args[0] == microgrid_pb2.SetBoundsParam(
         component_id=99,
-        target_metric=PbSetBoundsParam.TargetMetric.TARGET_METRIC_POWER_ACTIVE,
+        target_metric=microgrid_pb2.SetBoundsParam.TargetMetric.TARGET_METRIC_POWER_ACTIVE,
         bounds=bounds,
     )
 
@@ -601,16 +639,18 @@ async def test_set_bounds_ok(bounds: PbBounds, inverter99: PbComponent) -> None:
 @pytest.mark.parametrize(
     "bounds",
     [
-        PbBounds(lower=0.0, upper=-2.0),
-        PbBounds(lower=10.0, upper=-2.0),
-        PbBounds(lower=10.0, upper=0.0),
+        metrics_pb2.Bounds(lower=0.0, upper=-2.0),
+        metrics_pb2.Bounds(lower=10.0, upper=-2.0),
+        metrics_pb2.Bounds(lower=10.0, upper=0.0),
     ],
     ids=str,
 )
-async def test_set_bounds_fail(bounds: PbBounds, inverter99: PbComponent) -> None:
+async def test_set_bounds_fail(
+    bounds: metrics_pb2.Bounds, inverter99: microgrid_pb2.Component
+) -> None:
     """Test if charge is able to charge component."""
     client = _TestClient()
-    client.mock_stub.ListComponents.return_value = PbComponentList(
+    client.mock_stub.ListComponents.return_value = microgrid_pb2.ComponentList(
         components=[inverter99]
     )
 
@@ -638,25 +678,27 @@ async def test_set_bounds_grpc_error() -> None:
         await client.set_bounds(99, 0.0, 100.0)
 
 
-def _clear_components(component_list: PbComponentList) -> None:
+def _clear_components(component_list: microgrid_pb2.ComponentList) -> None:
     while component_list.components:
         component_list.components.pop()
 
 
 def _replace_components(
-    component_list: PbComponentList, components: list[PbComponent]
+    component_list: microgrid_pb2.ComponentList,
+    components: list[microgrid_pb2.Component],
 ) -> None:
     _clear_components(component_list)
     component_list.components.extend(components)
 
 
-def _clear_connections(connection_list: PbConnectionList) -> None:
+def _clear_connections(connection_list: microgrid_pb2.ConnectionList) -> None:
     while connection_list.connections:
         connection_list.connections.pop()
 
 
 def _replace_connections(
-    connection_list: PbConnectionList, connections: list[PbConnection]
+    connection_list: microgrid_pb2.ConnectionList,
+    connections: list[microgrid_pb2.Connection],
 ) -> None:
     _clear_connections(connection_list)
     connection_list.connections.extend(connections)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,8 +11,6 @@ from unittest import mock
 
 import grpc.aio
 import pytest
-
-# pylint: disable=no-name-in-module
 from frequenz.api.common.components_pb2 import ComponentCategory as PbComponentCategory
 from frequenz.api.common.components_pb2 import InverterType as PbInverterType
 from frequenz.api.common.metrics_pb2 import Bounds as PbBounds
@@ -28,8 +26,6 @@ from frequenz.api.microgrid.microgrid_pb2 import SetBoundsParam as PbSetBoundsPa
 from frequenz.api.microgrid.microgrid_pb2 import (
     SetPowerActiveParam as PbSetPowerActiveParam,
 )
-
-# pylint: enable=no-name-in-module
 from frequenz.client.base import retry
 
 from frequenz.client.microgrid import (

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -4,7 +4,7 @@
 """Tests for the microgrid component wrapper."""
 
 import pytest
-from frequenz.api.common.components_pb2 import ComponentCategory as PbComponentCategory
+from frequenz.api.common import components_pb2
 
 from frequenz.client.microgrid._component import (
     Component,
@@ -17,36 +17,42 @@ def test_component_category_from_protobuf() -> None:
     """Test the creating component category from protobuf."""
     assert (
         component_category_from_protobuf(
-            PbComponentCategory.COMPONENT_CATEGORY_UNSPECIFIED
+            components_pb2.ComponentCategory.COMPONENT_CATEGORY_UNSPECIFIED
         )
         == ComponentCategory.NONE
     )
 
     assert (
-        component_category_from_protobuf(PbComponentCategory.COMPONENT_CATEGORY_GRID)
+        component_category_from_protobuf(
+            components_pb2.ComponentCategory.COMPONENT_CATEGORY_GRID
+        )
         == ComponentCategory.GRID
     )
 
     assert (
-        component_category_from_protobuf(PbComponentCategory.COMPONENT_CATEGORY_METER)
+        component_category_from_protobuf(
+            components_pb2.ComponentCategory.COMPONENT_CATEGORY_METER
+        )
         == ComponentCategory.METER
     )
 
     assert (
         component_category_from_protobuf(
-            PbComponentCategory.COMPONENT_CATEGORY_INVERTER
+            components_pb2.ComponentCategory.COMPONENT_CATEGORY_INVERTER
         )
         == ComponentCategory.INVERTER
     )
 
     assert (
-        component_category_from_protobuf(PbComponentCategory.COMPONENT_CATEGORY_BATTERY)
+        component_category_from_protobuf(
+            components_pb2.ComponentCategory.COMPONENT_CATEGORY_BATTERY
+        )
         == ComponentCategory.BATTERY
     )
 
     assert (
         component_category_from_protobuf(
-            PbComponentCategory.COMPONENT_CATEGORY_EV_CHARGER
+            components_pb2.ComponentCategory.COMPONENT_CATEGORY_EV_CHARGER
         )
         == ComponentCategory.EV_CHARGER
     )
@@ -54,7 +60,9 @@ def test_component_category_from_protobuf() -> None:
     assert component_category_from_protobuf(666) == ComponentCategory.NONE  # type: ignore
 
     with pytest.raises(ValueError):
-        component_category_from_protobuf(PbComponentCategory.COMPONENT_CATEGORY_SENSOR)
+        component_category_from_protobuf(
+            components_pb2.ComponentCategory.COMPONENT_CATEGORY_SENSOR
+        )
 
 
 # pylint: disable=invalid-name

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -4,11 +4,8 @@
 """Tests for the microgrid component wrapper."""
 
 import pytest
-
-# pylint: disable=no-name-in-module
 from frequenz.api.common.components_pb2 import ComponentCategory as PbComponentCategory
 
-# pylint: enable=no-name-in-module
 from frequenz.client.microgrid._component import (
     Component,
     ComponentCategory,

--- a/tests/test_component_data.py
+++ b/tests/test_component_data.py
@@ -6,8 +6,6 @@
 from datetime import datetime, timezone
 
 import pytest
-
-# pylint: disable=no-name-in-module
 from frequenz.api.common.metrics.electrical_pb2 import AC as PbAc
 from frequenz.api.common.metrics_pb2 import Bounds as PbBounds
 from frequenz.api.common.metrics_pb2 import Metric as PbMetric
@@ -21,7 +19,6 @@ from frequenz.api.microgrid.inverter_pb2 import State as PbInverterState
 from frequenz.api.microgrid.microgrid_pb2 import ComponentData as PbComponentData
 from google.protobuf.timestamp_pb2 import Timestamp
 
-# pylint: enable=no-name-in-module
 from frequenz.client.microgrid import (
     ComponentData,
     InverterComponentState,

--- a/tests/test_component_data.py
+++ b/tests/test_component_data.py
@@ -6,18 +6,10 @@
 from datetime import datetime, timezone
 
 import pytest
-from frequenz.api.common.metrics.electrical_pb2 import AC as PbAc
-from frequenz.api.common.metrics_pb2 import Bounds as PbBounds
-from frequenz.api.common.metrics_pb2 import Metric as PbMetric
-from frequenz.api.microgrid.inverter_pb2 import (
-    ComponentState as PbInverterComponentState,
-)
-from frequenz.api.microgrid.inverter_pb2 import Data as PbInverterData
-from frequenz.api.microgrid.inverter_pb2 import Error as PbInverterError
-from frequenz.api.microgrid.inverter_pb2 import Inverter as PbInverter
-from frequenz.api.microgrid.inverter_pb2 import State as PbInverterState
-from frequenz.api.microgrid.microgrid_pb2 import ComponentData as PbComponentData
-from google.protobuf.timestamp_pb2 import Timestamp
+from frequenz.api.common import metrics_pb2
+from frequenz.api.common.metrics import electrical_pb2
+from frequenz.api.microgrid import inverter_pb2, microgrid_pb2
+from google.protobuf import timestamp_pb2
 
 from frequenz.client.microgrid import (
     ComponentData,
@@ -38,48 +30,52 @@ def test_inverter_data() -> None:
     """Verify the constructor for the InverterData class."""
     seconds = 1234567890
 
-    raw = PbComponentData(
+    raw = microgrid_pb2.ComponentData(
         id=5,
-        ts=Timestamp(seconds=seconds),
-        inverter=PbInverter(
-            state=PbInverterState(
-                component_state=PbInverterComponentState.COMPONENT_STATE_DISCHARGING
+        ts=timestamp_pb2.Timestamp(seconds=seconds),
+        inverter=inverter_pb2.Inverter(
+            state=inverter_pb2.State(
+                component_state=inverter_pb2.ComponentState.COMPONENT_STATE_DISCHARGING
             ),
-            errors=[PbInverterError(msg="error message")],
-            data=PbInverterData(
-                ac=PbAc(
-                    frequency=PbMetric(value=50.1),
-                    power_active=PbMetric(
+            errors=[inverter_pb2.Error(msg="error message")],
+            data=inverter_pb2.Data(
+                ac=electrical_pb2.AC(
+                    frequency=metrics_pb2.Metric(value=50.1),
+                    power_active=metrics_pb2.Metric(
                         value=100.2,
-                        system_exclusion_bounds=PbBounds(lower=-501.0, upper=501.0),
-                        system_inclusion_bounds=PbBounds(
+                        system_exclusion_bounds=metrics_pb2.Bounds(
+                            lower=-501.0, upper=501.0
+                        ),
+                        system_inclusion_bounds=metrics_pb2.Bounds(
                             lower=-51_000.0, upper=51_000.0
                         ),
                     ),
-                    power_reactive=PbMetric(
+                    power_reactive=metrics_pb2.Metric(
                         value=200.3,
-                        system_exclusion_bounds=PbBounds(lower=-502.0, upper=502.0),
-                        system_inclusion_bounds=PbBounds(
+                        system_exclusion_bounds=metrics_pb2.Bounds(
+                            lower=-502.0, upper=502.0
+                        ),
+                        system_inclusion_bounds=metrics_pb2.Bounds(
                             lower=-52_000.0, upper=52_000.0
                         ),
                     ),
-                    phase_1=PbAc.ACPhase(
-                        current=PbMetric(value=12.3),
-                        voltage=PbMetric(value=229.8),
-                        power_active=PbMetric(value=33.1),
-                        power_reactive=PbMetric(value=10.1),
+                    phase_1=electrical_pb2.AC.ACPhase(
+                        current=metrics_pb2.Metric(value=12.3),
+                        voltage=metrics_pb2.Metric(value=229.8),
+                        power_active=metrics_pb2.Metric(value=33.1),
+                        power_reactive=metrics_pb2.Metric(value=10.1),
                     ),
-                    phase_2=PbAc.ACPhase(
-                        current=PbMetric(value=23.4),
-                        voltage=PbMetric(value=230.0),
-                        power_active=PbMetric(value=33.3),
-                        power_reactive=PbMetric(value=10.2),
+                    phase_2=electrical_pb2.AC.ACPhase(
+                        current=metrics_pb2.Metric(value=23.4),
+                        voltage=metrics_pb2.Metric(value=230.0),
+                        power_active=metrics_pb2.Metric(value=33.3),
+                        power_reactive=metrics_pb2.Metric(value=10.2),
                     ),
-                    phase_3=PbAc.ACPhase(
-                        current=PbMetric(value=34.5),
-                        voltage=PbMetric(value=230.2),
-                        power_active=PbMetric(value=33.8),
-                        power_reactive=PbMetric(value=10.3),
+                    phase_3=electrical_pb2.AC.ACPhase(
+                        current=metrics_pb2.Metric(value=34.5),
+                        voltage=metrics_pb2.Metric(value=230.2),
+                        power_active=metrics_pb2.Metric(value=33.8),
+                        power_reactive=metrics_pb2.Metric(value=10.3),
                     ),
                 ),
             ),


### PR DESCRIPTION
We can disable this rule because `mypy` already checks for this kind of errors and this also fixes a long-standing issue with `pylint` that can't figure out protobuf generate stuff have some members:

* https://github.com/pylint-dev/pylint/issues/6281

And now that we disabled this check we can just use the protobuf modules instead of having to declare one alias per each symbol we need. We did this before just so we only need to use a `pylint` `disable=no-name-in-module` one time in the import instead each time we **used** the symbol.
