### PR TITLE
Disable SSL by default

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,7 +27,7 @@ updates:
           - "patch"
         exclude-patterns:
           - "frequenz-client-base*"
-          - "frequenz-microgrid-betterproto*"
+          - "frequenz-api-microgrid"
       optional:
         dependency-type: "development"
         update-types:
@@ -35,11 +35,11 @@ updates:
           - "patch"
         exclude-patterns:
           - "frequenz-client-base*"
-          - "frequenz-microgrid-betterproto*"
+          - "frequenz-api-microgrid"
       in-devel-patch:
         patterns:
           - "frequenz-client-base*"
-          - "frequenz-microgrid-betterproto*"
+          - "frequenz-api-microgrid"
         dependency-type: "production"
         update-types:
           - "patch"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,5 @@
 # Frequenz Microgrid API Client Release Notes
 
-## Summary
-
-<!-- Here goes a general summary of what this release is about -->
-
-## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Fix a bug where SSL was enabled by default. It is now disabled by default as in previous versions.


### PR DESCRIPTION
The microgrid API does not use SSL by default, so it makes sense to disable it by default in the client. This was the behavior in previous versions, and it was changed by mistake in a previous commit.

Also prepare the release notes for the next patch release.
