### PR TITLE
Inherit from `BaseApiClient`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,7 +13,7 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- The client now inherits from `frequenz.client.base.BaseApiClient`, so it provides a few new features, like `disconnect()`ing or using it as a context manager. Please refer to the [`BaseApiClient` documentation](https://frequenz-floss.github.io/frequenz-client-base-python/latest/reference/frequenz/client/base/client/#frequenz.client.base.client.BaseApiClient) for more information on these features.
 
 ## Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@
 
     * The class was renamed to `MicrogridApiClient`.
     * The `api` attribute was renamed to `stub`.
+    * The constructor parameter `channel_options` was renamed to `channels_defaults` to match the name used in `BaseApiClient`.
     * The constructor now accepts a `connect` parameter, which is `True` by default. If set to `False`, the client will not connect to the server upon instantiation. You can connect later by calling the `connect()` method.
 
 ## New Features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@
 
     * The class was renamed to `MicrogridApiClient`.
     * The `api` attribute was renamed to `stub`.
+    * The constructor now accepts a `connect` parameter, which is `True` by default. If set to `False`, the client will not connect to the server upon instantiation. You can connect later by calling the `connect()` method.
 
 ## New Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,10 @@
 
 ## Upgrading
 
-- The `ApiClient` class was renamed to `MicrogridApiClient`.
+- `ApiClient`:
+
+    * The class was renamed to `MicrogridApiClient`.
+    * The `api` attribute was renamed to `stub`.
 
 ## New Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- The `ApiClient` class was renamed to `MicrogridApiClient`.
 
 ## New Features
 

--- a/src/frequenz/client/microgrid/__init__.py
+++ b/src/frequenz/client/microgrid/__init__.py
@@ -7,7 +7,7 @@ This package provides a low-level interface for interacting with the microgrid A
 """
 
 
-from ._client import ApiClient
+from ._client import MicrogridApiClient
 from ._component import (
     Component,
     ComponentCategory,
@@ -65,7 +65,7 @@ from ._exception import (
 from ._metadata import Location, Metadata
 
 __all__ = [
-    "ApiClient",
+    "MicrogridApiClient",
     "ApiClientError",
     "BatteryComponentState",
     "BatteryData",

--- a/src/frequenz/client/microgrid/_client.py
+++ b/src/frequenz/client/microgrid/_client.py
@@ -55,7 +55,7 @@ microgrid API does not use SSL by default.
 """
 
 
-class ApiClient:
+class MicrogridApiClient:
     """A microgrid API client."""
 
     def __init__(

--- a/src/frequenz/client/microgrid/_client.py
+++ b/src/frequenz/client/microgrid/_client.py
@@ -62,7 +62,7 @@ class MicrogridApiClient(client.BaseApiClient[microgrid_pb2_grpc.MicrogridStub])
         self,
         server_url: str,
         *,
-        channel_options: channel.ChannelOptions = DEFAULT_CHANNEL_OPTIONS,
+        channel_defaults: channel.ChannelOptions = DEFAULT_CHANNEL_OPTIONS,
         connect: bool = True,
         retry_strategy: retry.Strategy | None = None,
     ) -> None:
@@ -75,7 +75,7 @@ class MicrogridApiClient(client.BaseApiClient[microgrid_pb2_grpc.MicrogridStub])
                 where the `port` should be an int between 0 and 65535 (defaulting to
                 9090) and `ssl` should be a boolean (defaulting to `false`).
                 For example: `grpc://localhost:1090?ssl=true`.
-            channel_options: The default options use to create the channel when not
+            channel_defaults: The default options use to create the channel when not
                 specified in the URL.
             connect: Whether to connect to the server as soon as a client instance is
                 created. If `False`, the client will not connect to the server until
@@ -89,7 +89,7 @@ class MicrogridApiClient(client.BaseApiClient[microgrid_pb2_grpc.MicrogridStub])
             server_url,
             microgrid_pb2_grpc.MicrogridStub,
             connect=connect,
-            channel_defaults=channel_options,
+            channel_defaults=channel_defaults,
         )
         self._broadcasters: dict[int, streaming.GrpcStreamBroadcaster[Any, Any]] = {}
         self._retry_strategy = retry_strategy

--- a/src/frequenz/client/microgrid/_client.py
+++ b/src/frequenz/client/microgrid/_client.py
@@ -63,6 +63,7 @@ class MicrogridApiClient(client.BaseApiClient[microgrid_pb2_grpc.MicrogridStub])
         server_url: str,
         *,
         channel_options: channel.ChannelOptions = DEFAULT_CHANNEL_OPTIONS,
+        connect: bool = True,
         retry_strategy: retry.Strategy | None = None,
     ) -> None:
         """Initialize the class instance.
@@ -76,6 +77,10 @@ class MicrogridApiClient(client.BaseApiClient[microgrid_pb2_grpc.MicrogridStub])
                 For example: `grpc://localhost:1090?ssl=true`.
             channel_options: The default options use to create the channel when not
                 specified in the URL.
+            connect: Whether to connect to the server as soon as a client instance is
+                created. If `False`, the client will not connect to the server until
+                [connect()][frequenz.client.base.client.BaseApiClient.connect] is
+                called.
             retry_strategy: The retry strategy to use to reconnect when the connection
                 to the streaming method is lost. By default a linear backoff strategy
                 is used.
@@ -83,6 +88,7 @@ class MicrogridApiClient(client.BaseApiClient[microgrid_pb2_grpc.MicrogridStub])
         super().__init__(
             server_url,
             microgrid_pb2_grpc.MicrogridStub,
+            connect=connect,
             channel_defaults=channel_options,
         )
         self._broadcasters: dict[int, streaming.GrpcStreamBroadcaster[Any, Any]] = {}

--- a/src/frequenz/client/microgrid/_client.py
+++ b/src/frequenz/client/microgrid/_client.py
@@ -83,7 +83,7 @@ class MicrogridApiClient:
         self._server_url = server_url
         """The location of the microgrid API server as a URL."""
 
-        self.api = microgrid_pb2_grpc.MicrogridStub(
+        self.stub = microgrid_pb2_grpc.MicrogridStub(
             channel.parse_grpc_uri(server_url, defaults=channel_options)
         )
         """The gRPC stub for the microgrid API."""
@@ -112,7 +112,7 @@ class MicrogridApiClient:
             # but it is
             component_list = await cast(
                 Awaitable[microgrid_pb2.ComponentList],
-                self.api.ListComponents(
+                self.stub.ListComponents(
                     microgrid_pb2.ComponentFilter(),
                     timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
                 ),
@@ -154,7 +154,7 @@ class MicrogridApiClient:
         try:
             microgrid_metadata = await cast(
                 Awaitable[microgrid_pb2.MicrogridMetadata],
-                self.api.GetMicrogridMetadata(
+                self.stub.GetMicrogridMetadata(
                     Empty(),
                     timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
                 ),
@@ -203,7 +203,7 @@ class MicrogridApiClient:
                 # awaitable, but it is
                 cast(
                     Awaitable[microgrid_pb2.ConnectionList],
-                    self.api.ListConnections(
+                    self.stub.ListConnections(
                         connection_filter,
                         timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
                     ),
@@ -269,7 +269,7 @@ class MicrogridApiClient:
                 # microgrid_pb2.ComponentData], which it is.
                 lambda: cast(
                     AsyncIterator[microgrid_pb2.ComponentData],
-                    self.api.StreamComponentData(
+                    self.stub.StreamComponentData(
                         microgrid_pb2.ComponentIdParam(id=component_id)
                     ),
                 ),
@@ -427,7 +427,7 @@ class MicrogridApiClient:
         try:
             await cast(
                 Awaitable[Empty],
-                self.api.SetPowerActive(
+                self.stub.SetPowerActive(
                     microgrid_pb2.SetPowerActiveParam(
                         component_id=component_id, power=power_w
                     ),
@@ -472,7 +472,7 @@ class MicrogridApiClient:
         try:
             await cast(
                 Awaitable[Timestamp],
-                self.api.AddInclusionBounds(
+                self.stub.AddInclusionBounds(
                     microgrid_pb2.SetBoundsParam(
                         component_id=component_id,
                         target_metric=target_metric,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,7 +16,6 @@ from frequenz.api.microgrid import grid_pb2, inverter_pb2, microgrid_pb2
 from frequenz.client.base import retry
 
 from frequenz.client.microgrid import (
-    MicrogridApiClient,
     ApiClientError,
     BatteryData,
     Component,
@@ -28,6 +27,7 @@ from frequenz.client.microgrid import (
     InverterData,
     InverterType,
     MeterData,
+    MicrogridApiClient,
 )
 from frequenz.client.microgrid._connection import Connection
 
@@ -46,7 +46,7 @@ class _TestClient(MicrogridApiClient):
         mock_stub.StreamComponentData = mock.Mock("StreamComponentData")
         super().__init__("grpc://mock_host:1234", retry_strategy=retry_strategy)
         self.mock_stub = mock_stub
-        self.api = mock_stub
+        self.stub = mock_stub
 
 
 async def test_components() -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -46,7 +46,7 @@ class _TestClient(MicrogridApiClient):
         mock_stub.StreamComponentData = mock.Mock("StreamComponentData")
         super().__init__("grpc://mock_host:1234", retry_strategy=retry_strategy)
         self.mock_stub = mock_stub
-        self.stub = mock_stub
+        self._stub = mock_stub  # pylint: disable=protected-access
 
 
 async def test_components() -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,7 +16,7 @@ from frequenz.api.microgrid import grid_pb2, inverter_pb2, microgrid_pb2
 from frequenz.client.base import retry
 
 from frequenz.client.microgrid import (
-    ApiClient,
+    MicrogridApiClient,
     ApiClientError,
     BatteryData,
     Component,
@@ -32,7 +32,7 @@ from frequenz.client.microgrid import (
 from frequenz.client.microgrid._connection import Connection
 
 
-class _TestClient(ApiClient):
+class _TestClient(MicrogridApiClient):
     def __init__(self, *, retry_strategy: retry.Strategy | None = None) -> None:
         # Here we sadly can't use spec=MicrogridStub because the generated stub typing
         # is a mess, and for some reason inspection of gRPC methods doesn't work.


### PR DESCRIPTION
- **Rename `ApiClient` to `MicrogridApiClient`**
- **Rename the `api` attribute to `stub`**
- **Make `MicrogridApiClient` inherit from `BaseApiClient`**
- **Add a `connect` parameter to the `MicrogridApiClient` constructor**
- **Rename `channel_options` to `channels_defaults`**
