### PR TITLE
Use `call_stub_method()` to call stub methods

### DIFF
--- a/src/frequenz/client/microgrid/_client.py
+++ b/src/frequenz/client/microgrid/_client.py
@@ -5,9 +5,9 @@
 
 import asyncio
 import logging
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Set
+from collections.abc import Callable, Iterable, Set
 from dataclasses import replace
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar
 
 import grpc.aio
 from frequenz.api.common import components_pb2, metrics_pb2
@@ -15,7 +15,6 @@ from frequenz.api.microgrid import microgrid_pb2, microgrid_pb2_grpc
 from frequenz.channels import Receiver
 from frequenz.client.base import channel, client, retry, streaming
 from google.protobuf.empty_pb2 import Empty
-from google.protobuf.timestamp_pb2 import Timestamp
 
 from ._component import (
     Component,
@@ -91,6 +90,7 @@ class MicrogridApiClient(client.BaseApiClient[microgrid_pb2_grpc.MicrogridStub])
             connect=connect,
             channel_defaults=channel_defaults,
         )
+        self._async_stub: microgrid_pb2_grpc.MicrogridAsyncStub = self.stub  # type: ignore
         self._broadcasters: dict[int, streaming.GrpcStreamBroadcaster[Any, Any]] = {}
         self._retry_strategy = retry_strategy
 
@@ -106,14 +106,9 @@ class MicrogridApiClient(client.BaseApiClient[microgrid_pb2_grpc.MicrogridStub])
                 [GrpcError][frequenz.client.microgrid.GrpcError].
         """
         try:
-            # grpc.aio is missing types and mypy thinks this is not awaitable,
-            # but it is
-            component_list = await cast(
-                Awaitable[microgrid_pb2.ComponentList],
-                self.stub.ListComponents(
-                    microgrid_pb2.ComponentFilter(),
-                    timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
-                ),
+            component_list = await self._async_stub.ListComponents(
+                microgrid_pb2.ComponentFilter(),
+                timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
             )
         except grpc.aio.AioRpcError as grpc_error:
             raise ApiClientError.from_grpc_error(
@@ -150,12 +145,9 @@ class MicrogridApiClient(client.BaseApiClient[microgrid_pb2_grpc.MicrogridStub])
         """
         microgrid_metadata: microgrid_pb2.MicrogridMetadata | None = None
         try:
-            microgrid_metadata = await cast(
-                Awaitable[microgrid_pb2.MicrogridMetadata],
-                self.stub.GetMicrogridMetadata(
-                    Empty(),
-                    timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
-                ),
+            microgrid_metadata = await self._async_stub.GetMicrogridMetadata(
+                Empty(),
+                timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
             )
         except grpc.aio.AioRpcError:
             _logger.exception("The microgrid metadata is not available.")
@@ -197,14 +189,9 @@ class MicrogridApiClient(client.BaseApiClient[microgrid_pb2_grpc.MicrogridStub])
         try:
             valid_components, all_connections = await asyncio.gather(
                 self.components(),
-                # grpc.aio is missing types and mypy thinks this is not
-                # awaitable, but it is
-                cast(
-                    Awaitable[microgrid_pb2.ConnectionList],
-                    self.stub.ListConnections(
-                        connection_filter,
-                        timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
-                    ),
+                self._async_stub.ListConnections(
+                    connection_filter,
+                    timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
                 ),
             )
         except grpc.aio.AioRpcError as grpc_error:
@@ -261,15 +248,10 @@ class MicrogridApiClient(client.BaseApiClient[microgrid_pb2_grpc.MicrogridStub])
         if broadcaster is None:
             broadcaster = streaming.GrpcStreamBroadcaster(
                 f"raw-component-data-{component_id}",
-                # We need to cast here because grpc says StreamComponentData is
-                # a grpc.CallIterator[microgrid_pb2.ComponentData] which is not an
-                # AsyncIterator, but it is a grpc.aio.UnaryStreamCall[...,
-                # microgrid_pb2.ComponentData], which it is.
-                lambda: cast(
-                    AsyncIterator[microgrid_pb2.ComponentData],
-                    self.stub.StreamComponentData(
+                lambda: aiter(
+                    self._async_stub.StreamComponentData(
                         microgrid_pb2.ComponentIdParam(id=component_id)
-                    ),
+                    )
                 ),
                 transform,
                 retry_strategy=self._retry_strategy,
@@ -423,14 +405,11 @@ class MicrogridApiClient(client.BaseApiClient[microgrid_pb2_grpc.MicrogridStub])
                 [GrpcError][frequenz.client.microgrid.GrpcError].
         """
         try:
-            await cast(
-                Awaitable[Empty],
-                self.stub.SetPowerActive(
-                    microgrid_pb2.SetPowerActiveParam(
-                        component_id=component_id, power=power_w
-                    ),
-                    timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
+            await self._async_stub.SetPowerActive(
+                microgrid_pb2.SetPowerActiveParam(
+                    component_id=component_id, power=power_w
                 ),
+                timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
             )
         except grpc.aio.AioRpcError as grpc_error:
             raise ApiClientError.from_grpc_error(
@@ -468,16 +447,13 @@ class MicrogridApiClient(client.BaseApiClient[microgrid_pb2_grpc.MicrogridStub])
             microgrid_pb2.SetBoundsParam.TargetMetric.TARGET_METRIC_POWER_ACTIVE
         )
         try:
-            await cast(
-                Awaitable[Timestamp],
-                self.stub.AddInclusionBounds(
-                    microgrid_pb2.SetBoundsParam(
-                        component_id=component_id,
-                        target_metric=target_metric,
-                        bounds=metrics_pb2.Bounds(lower=lower, upper=upper),
-                    ),
-                    timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
+            await self._async_stub.AddInclusionBounds(
+                microgrid_pb2.SetBoundsParam(
+                    component_id=component_id,
+                    target_metric=target_metric,
+                    bounds=metrics_pb2.Bounds(lower=lower, upper=upper),
                 ),
+                timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
             )
         except grpc.aio.AioRpcError as grpc_error:
             raise ApiClientError.from_grpc_error(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -47,6 +47,7 @@ class _TestClient(MicrogridApiClient):
         super().__init__("grpc://mock_host:1234", retry_strategy=retry_strategy)
         self.mock_stub = mock_stub
         self._stub = mock_stub  # pylint: disable=protected-access
+        self._async_stub = mock_stub  # pylint: disable=protected-access
 
 
 async def test_components() -> None:


### PR DESCRIPTION
This utility function from `frequenz-client-base` simplifies the implementation of the client methods that call the gRPC stub methods, automatically converting the gRPC errors to `ApiClientError` exceptions.

We also now use the `MicrogridAsyncStub` type for the async stub internally, so we don't need to cast sync stuff to async anymore.

