### PR TITLE
Update the `client-base` dependency to v0.8.0

### DIFF
--- a/.github/containers/test-installation/Dockerfile
+++ b/.github/containers/test-installation/Dockerfile
@@ -3,7 +3,7 @@
 # This Dockerfile is used to test the installation of the python package in
 # multiple platforms in the CI. It is not used to build the package itself.
 
-FROM --platform=${TARGETPLATFORM} python:3.11-slim
+FROM python:3.11-slim
 
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,8 @@
     * The constructor parameter `channel_options` was renamed to `channels_defaults` to match the name used in `BaseApiClient`.
     * The constructor now accepts a `connect` parameter, which is `True` by default. If set to `False`, the client will not connect to the server upon instantiation. You can connect later by calling the `connect()` method.
 
+* The `frequenz-client-base` dependency was bumped to v0.8.0.
+
 ## New Features
 
 - The client now inherits from `frequenz.client.base.BaseApiClient`, so it provides a few new features, like `disconnect()`ing or using it as a context manager. Please refer to the [`BaseApiClient` documentation](https://frequenz-floss.github.io/frequenz-client-base-python/latest/reference/frequenz/client/base/client/#frequenz.client.base.client.BaseApiClient) for more information on these features.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ requires-python = ">= 3.11, < 4"
 dependencies = [
   "frequenz-api-microgrid >= 0.15.3, < 0.16.0",
   "frequenz-channels >= 1.0.0-rc1, < 2.0.0",
-  "frequenz-client-base >= 0.6.0, < 0.7",
+  "frequenz-client-base >= 0.8.0, < 0.9",
   "grpcio >= 1.54.2, < 2",
   "protobuf >= 4.21.6, < 6",
   "timezonefinder >= 6.2.0, < 7",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -47,7 +47,6 @@ class _TestClient(MicrogridApiClient):
         super().__init__("grpc://mock_host:1234", retry_strategy=retry_strategy)
         self.mock_stub = mock_stub
         self._stub = mock_stub  # pylint: disable=protected-access
-        self._async_stub = mock_stub  # pylint: disable=protected-access
 
 
 async def test_components() -> None:


### PR DESCRIPTION
We now use the new suggested way to get the `stub`, so it has proper async type hints.

We also enable the old behavior to retry on stream exhaustion because we don't expect data streaming to end normally, so we want to keep retrying if that happens.
