### PR TITLE
Revert "Enable autorefs plugin option to resolve closest references"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,8 +87,6 @@ markdown_extensions:
       permalink: "¤"
 
 plugins:
-  - autorefs:
-      resolve_closest: true
   - gen-files:
       scripts:
         - docs/_scripts/mkdocstrings_autoapi.py


### PR DESCRIPTION
We needed this to workaround an issue that was fixed upstream in autorefs v1.3.1.

See https://github.com/mkdocstrings/autorefs/issues/52#issuecomment-2650901481.

This reverts commit 1aab7b5cc874dba8bcd53c42842e78c17402a62e.
