### PR TITLE
Exclude repo-config from dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
     # Major updates are still managed, but they'll create one PR per
     # dependency, as major updates are expected to be breaking, it is better to
     # manage them individually.
+    # We exclude the `frequenz-repo-config` package from grouping as this
+    # dependency is still under development (at branch v0.x.x), so minor
+    # changes typically introduce breaking changes (and patch updates can
+    # potentially too according to semver).
     groups:
       required:
         dependency-type: "production"
@@ -26,6 +30,7 @@ updates:
           - "minor"
           - "patch"
         exclude-patterns:
+          - "frequenz-repo-config"
           - "frequenz-client-base*"
           - "frequenz-api-microgrid"
       optional:
@@ -34,6 +39,7 @@ updates:
           - "minor"
           - "patch"
         exclude-patterns:
+          - "frequenz-repo-config"
           - "frequenz-client-base*"
           - "frequenz-api-microgrid"
       in-devel-patch:


### PR DESCRIPTION
This dependency usually need manual intervention to update, so it's better to exclude it from the grouping, which usually blocks merging until the manual intervention happens.
