### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-dependabot.yaml
+++ b/.github/workflows/auto-dependabot.yaml
@@ -1,0 +1,19 @@
+name: Auto-merge Dependabot PRs
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-merge Dependabot PR
+        uses: ad/dependabot-auto-approve@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: 'merge'


### PR DESCRIPTION
## Summary
- Add GitHub workflow to automatically approve and merge Dependabot PRs
- Uses `merge` method for clean commit history