### PR TITLE
Remove the timeout from the gRPC stream call

### DIFF
--- a/src/frequenz/client/microgrid/_client.py
+++ b/src/frequenz/client/microgrid/_client.py
@@ -624,7 +624,6 @@ class MicrogridApiClient(client.BaseApiClient[microgrid_pb2_grpc.MicrogridStub])
                                 metrics=metrics_set
                             ),
                         ),
-                        timeout=DEFAULT_GRPC_CALL_TIMEOUT,
                     )
                 ),
                 lambda msg: component_data_samples_from_proto(msg.telemetry),

--- a/tests/client_test_cases/receive_component_data_samples_stream/empty_case.py
+++ b/tests/client_test_cases/receive_component_data_samples_stream/empty_case.py
@@ -29,8 +29,7 @@ def assert_stub_method_call(stub_method: Any) -> None:
         microgrid_pb2.ReceiveElectricalComponentTelemetryStreamRequest(
             electrical_component_id=1,
             filter=_Filter(metrics=[metrics_pb2.Metric.METRIC_AC_CURRENT]),
-        ),
-        timeout=60.0,
+        )
     )
 
 

--- a/tests/client_test_cases/receive_component_data_samples_stream/error_case.py
+++ b/tests/client_test_cases/receive_component_data_samples_stream/error_case.py
@@ -33,8 +33,7 @@ def assert_stub_method_call(stub_method: Any) -> None:
         microgrid_pb2.ReceiveElectricalComponentTelemetryStreamRequest(
             electrical_component_id=1,
             filter=_Filter(metrics=[metrics_pb2.Metric.METRIC_DC_VOLTAGE]),
-        ),
-        timeout=60.0,
+        )
     )
 
 

--- a/tests/client_test_cases/receive_component_data_samples_stream/many_case.py
+++ b/tests/client_test_cases/receive_component_data_samples_stream/many_case.py
@@ -44,8 +44,7 @@ def assert_stub_method_call(stub_method: Any) -> None:
                     metrics_pb2.Metric.METRIC_DC_CURRENT,
                 ]
             ),
-        ),
-        timeout=60.0,
+        )
     )
 
 


### PR DESCRIPTION
The timeout counts for the whole duration of the call, not each individual streamed message, so it always times out, as we expect this stream to basically last forever.

On top of this, disconnecting the stream seems to trigger some bug in the SDK, so we better avoid it for now.
