### PR TITLE
Migrate to frequenz-floss dependabot-auto-approve action

### DIFF
--- a/.github/workflows/auto-dependabot.yaml
+++ b/.github/workflows/auto-dependabot.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-merge Dependabot PR
-        uses: ad/dependabot-auto-approve@v1
+        uses: frequenz-floss/dependabot-auto-approve@3cad5f42e79296505473325ac6636be897c8b8a1 # v1.3.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           merge-method: 'merge'


### PR DESCRIPTION
Use commit hash instead of version tag for better security and reproducibility.