### PR TITLE
Add pylint exception for too-many-branches

### DIFF
--- a/src/frequenz/client/microgrid/component/_component_proto.py
+++ b/src/frequenz/client/microgrid/component/_component_proto.py
@@ -199,7 +199,7 @@ def component_base_from_proto_with_issues(
     )
 
 
-# pylint: disable-next=too-many-locals
+# pylint: disable-next=too-many-locals, too-many-branches
 def component_from_proto_with_issues(
     message: electrical_components_pb2.ElectricalComponent,
     *,


### PR DESCRIPTION
When converting a component from its protobuf representation, we need to handle multiple component types, so we end up with multiple branches in the function, but this is OK, so we just silence the pylint warning for that specific case.

This is in preparation to the merge to v0.x.x branch, as only the new version detects this case.
