### PR TITLE
ci: Use `ubuntu-24.04` for repo-config-migration

### DIFF
--- a/.github/workflows/repo-config-migration.yaml
+++ b/.github/workflows/repo-config-migration.yaml
@@ -31,7 +31,7 @@ jobs:
   repo-config-migration:
     name: Migrate Repo Config
     if: contains(github.event.pull_request.title, 'the repo-config group')
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: create-app-token


### PR DESCRIPTION
The migration action now requires docker, so we can't use the `ubuntu-slim` runner anymore, as it is a docker container itself and doesn't provide Docker in Docker.
